### PR TITLE
Jellyfin compatibility layer on AIOStreams v2.34.0

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,54 @@
+# AIOStreams-JF
+
+## What This Is
+
+Maged's build of AIOStreams (upstream Viren070/AIOStreams, tracking the latest release, v2.34.0 at start) with the Jellyfin compatibility layer published by qooode/AIOStreams ported on top. Jellyfin-compatible clients (Infuse, SenPlayer, Jellyfin web/desktop) log in with an AIOStreams profile UUID and password and get libraries, metadata, seasons/episodes, media sources, resume/next-up and favourites straight from that profile's own addons, with no Jellyfin server and no Remux/AioFin in between. AioMetadata inside each profile supplies catalogs, metadata and scrobbling.
+
+## Core Value
+
+Each AIOStreams profile is a complete Jellyfin server for its owner: their addons, their metadata provider, their streams in their order, their watch state, on the newest AIOStreams.
+
+## Requirements
+
+### Validated
+
+(None yet)
+
+### Active
+
+- [ ] The qooode Jellyfin layer (23 files + core hooks) is ported onto a clean AIOStreams v2.34.0 checkout, builds, and its own tests pass
+- [ ] A Docker image of the port runs as a parallel container on the Dubai VPS under its own hostname, with a copy of the production AIOStreams database, production untouched
+- [ ] The `maged-dxb` profile includes AioMetadata (catalogs + meta) and AioMetadata scrobbling is enabled
+- [ ] Infuse and SenPlayer log in with UUID/password and pass the checklist: catalogs as libraries, Solo Leveling structure per provider, Shawshank/Silo playback including uncached and usenet entries, explicit pick, resume and next-up, labels
+- [ ] Cut-over: the production instance runs the ported image with the previous image tag kept for rollback; the other two profiles get AioMetadata; AIOStreams-JF stays upgradeable when upstream releases
+
+### Out of Scope
+
+- Any Remux/AioFin work — discontinued 2026-09-07
+- Transcoding — the layer is direct-play by design (302 redirect); browser playback of remux/DTS is not a goal
+- Modifying upstream AIOStreams behaviour beyond the Jellyfin layer hooks — keeps the port rebaseable; if upstream adopts the layer officially, this repo is retired
+
+## Context
+
+- Repo: `/Users/magededward/opencode/aiostreams-jf-update`, GitHub `tweakapps/aiostreams-jf-update` (fork of Viren070/AIOStreams), branch `jellyfin-layer` from tag `v2.34.0`. Remotes: `origin` (fork), `upstream` (Viren070), `jflayer` (qooode/AIOStreams, single "Initial commit" snapshot of a 2.33.x dev tree + the layer). `tweakapps/AIOStreams-JF` is Maged's untouched mirror of qooode's repo.
+- Layer inventory (from qooode main): `packages/core/src/jellyfin/{index,service,dto,ids,ids-codec,images}.ts` (+ tests), `packages/core/src/db/repositories/jellyfin.ts`, migrations `0020_jellyfin.ts`, `0021_jellyfin_keys.ts`, `packages/server/src/routes/jellyfin/{index,context,items,library,playback,system,tasks,ws,relay-target}.ts` (+ test). Core hooks to re-apply live in roughly: `db/index.ts`, `db/migrations/index.ts`, `db/repositories/users.ts`, `config/schema/api.ts`, `formatters/base.ts`, `core/src/index.ts`, `server/src/app.ts`, `server/src/server.ts`, plus frontend `save-install.tsx` (Installation > Jellyfin tab) and `manifest.ts` bits. Verify each by diffing qooode's file against the same file at its nearest upstream ancestor, not against v2.34.0.
+- Production: `aiostreams-dxb.tweakstreams.stream` → Dubai Oracle VPS 145.241.123.188 (ssh `ubuntu@145.241.123.188`, key `~/.ssh/ssh-key-2026-06-13.key`, compose `~/apps/docker-compose.yml`, Traefik + Authelia). Running v2.34.0. Usenet via `nzbhydra2` on the same host. AioMetadata at `aiometadata.tweakstreams.stream` (Hetzner).
+- Profiles: `maged-dxb`, plus two family profiles (aligned formatter; `⌁` cached, `∅` uncached, `⧉` usenet).
+- Working rules: Fable plans/reviews; Sonnet executes; cost discipline (targeted reading, targeted tests, ≤25-line summaries); push to GitHub after every commit; never touch production containers/DB except via the documented cut-over step with backup.
+
+## Constraints
+
+- **Upstream tracking**: keep the layer as an additive patch on upstream tags; no unrelated edits to upstream files.
+- **Secrets**: profile UUIDs/passwords, manifest URLs, VPS keys never in the repo.
+- **Production safety**: parallel container with a DB copy first; cut-over only on Maged's explicit approval; rollback tag retained.
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|---|---|---|
+| Port the layer onto v2.34.0 rather than run qooode's 2.33.x snapshot | Maged wants the newest AIOStreams; the layer is 23 files + small hooks | — Pending |
+| Parallel deployment on a separate hostname before cut-over | Zero risk to the live profiles | — Pending |
+| AioMetadata inside the profile for catalogs, meta and scrobbling | Replaces AioFin's metadata-truth and watch-sync goals by construction | — Pending |
+
+---
+*Last updated: 2026-09-07 after initialization*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,40 @@
+# Requirements: AIOStreams-JF
+
+**Defined:** 2026-09-07
+**Core Value:** Each AIOStreams profile is a complete Jellyfin server for its owner.
+
+## v1 Requirements
+
+### Port
+- [ ] **PORT-01**: All qooode Jellyfin-layer files are present on `jellyfin-layer` with core hooks re-applied on v2.34.0; `pnpm install && pnpm build` succeeds
+- [ ] **PORT-02**: The layer's own tests (`ids.test.ts`, `images.test.ts`, `relay-target.test.ts`) and the upstream test suite pass
+- [ ] **PORT-03**: Migrations `0020_jellyfin`/`0021_jellyfin_keys` apply cleanly on a copy of the production database
+- [ ] **PORT-04**: A local run exposes `/jellyfin` (or the layer's mount) and `POST /Users/AuthenticateByName` succeeds with a profile UUID/password
+
+### Deploy
+- [ ] **DEP-01**: Docker image built from the branch and pushed to GHCR under `tweakapps`
+- [ ] **DEP-02**: Parallel container on the Dubai VPS with a DB copy, own hostname via Traefik, production container untouched
+- [ ] **DEP-03**: Rollback documented: previous image tag + DB backup path
+
+### Profile & Clients
+- [ ] **PROF-01**: AioMetadata added to `maged-dxb` with catalogs + meta; scrobbling enabled
+- [ ] **CLI-01**: Infuse: login, libraries, Solo Leveling seasons per provider, Shawshank + Silo playback (cached, uncached, usenet), explicit pick, resume/next-up
+- [ ] **CLI-02**: SenPlayer: same checklist
+- [ ] **CLI-03**: Labels match the profile formatter; evidence table written
+
+### Cut-over
+- [ ] **CUT-01**: Production switched to the ported image after Maged's approval; other profiles get AioMetadata; rollback verified possible
+
+## Out of Scope
+| Feature | Reason |
+|---|---|
+| Transcoding | direct-play layer by design |
+| Remux/AioFin | discontinued |
+
+## Traceability
+| Requirement | Phase | Status |
+|---|---|---|
+| PORT-01..04 | Phase 1 | Pending |
+| DEP-01..03 | Phase 2 | Pending |
+| PROF-01, CLI-01..03 | Phase 3 | Pending |
+| CUT-01 | Phase 4 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -34,7 +34,7 @@
 ## Traceability
 | Requirement | Phase | Status |
 |---|---|---|
-| PORT-01..04 | Phase 1 | Pending |
+| PORT-01..04 | Phase 1 | Complete |
 | DEP-01..03 | Phase 2 | Pending |
 | PROF-01, CLI-01..03 | Phase 3 | Pending |
 | CUT-01 | Phase 4 | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -6,7 +6,7 @@
 
 ## Phases
 
-- [ ] **Phase 1: Port** - Jellyfin layer ported onto v2.34.0, building and tested
+- [x] **Phase 1: Port** (completed 2026-09-08) - Jellyfin layer ported onto v2.34.0, building and tested
 - [ ] **Phase 2: Parallel Deploy** - Image on GHCR, parallel container on the Dubai VPS with a DB copy
 - [ ] **Phase 3: Profile & Clients** - AioMetadata in the profile, Infuse/SenPlayer checklist with evidence
 - [ ] **Phase 4: Cut-over** - Production on the ported image with rollback, all profiles

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,57 @@
+# Roadmap: AIOStreams-JF
+
+**Milestone:** Jellyfin layer on latest AIOStreams, live for Maged's profiles
+**Core Value:** Each AIOStreams profile is a complete Jellyfin server for its owner.
+**Granularity:** coarse
+
+## Phases
+
+- [ ] **Phase 1: Port** - Jellyfin layer ported onto v2.34.0, building and tested
+- [ ] **Phase 2: Parallel Deploy** - Image on GHCR, parallel container on the Dubai VPS with a DB copy
+- [ ] **Phase 3: Profile & Clients** - AioMetadata in the profile, Infuse/SenPlayer checklist with evidence
+- [ ] **Phase 4: Cut-over** - Production on the ported image with rollback, all profiles
+
+## Phase Details
+
+### Phase 1: Port
+**Goal**: The qooode Jellyfin layer works on a clean AIOStreams v2.34.0 checkout
+**Depends on**: Nothing
+**Requirements**: PORT-01, PORT-02, PORT-03, PORT-04
+**Success Criteria**:
+  1. `pnpm build` green on `jellyfin-layer`; layer tests + upstream tests pass
+  2. Migrations apply on a DB copy
+  3. Local login via UUID/password returns a token
+**Plans**: TBD
+**Executor**: Sonnet, Fable diff review
+
+### Phase 2: Parallel Deploy
+**Goal**: The port runs on the Dubai VPS next to production without touching it
+**Depends on**: Phase 1
+**Requirements**: DEP-01, DEP-02, DEP-03
+**Success Criteria**:
+  1. GHCR image `ghcr.io/tweakapps/aiostreams-jf-update:<tag>` exists
+  2. Parallel container answers `/System/Info/Public` on its hostname; production unchanged
+  3. Rollback path documented
+**Plans**: TBD
+**Executor**: Sonnet (SSH to Dubai VPS), Fable review of compose changes
+
+### Phase 3: Profile & Clients
+**Goal**: Maged's profile works end-to-end in Infuse and SenPlayer through the layer
+**Depends on**: Phase 2
+**Requirements**: PROF-01, CLI-01, CLI-02, CLI-03
+**Success Criteria**:
+  1. Libraries = profile catalogs via AioMetadata; Solo Leveling structure per provider
+  2. Playback of cached, uncached and usenet entries behaves as documented; explicit picks honoured
+  3. Resume / next-up / favourites persist per profile
+**Plans**: TBD
+**Executor**: Sonnet prepares; Maged tests; Fable reads evidence
+
+### Phase 4: Cut-over
+**Goal**: Production runs the ported image for all profiles with a rollback
+**Depends on**: Phase 3
+**Requirements**: CUT-01
+**Success Criteria**:
+  1. Maged's explicit approval recorded before the swap
+  2. Production container on the new image; old tag + DB backup retained; smoke passes
+**Plans**: TBD
+**Executor**: Sonnet with Fable step-by-step review

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,12 @@
+# State: AIOStreams-JF
+
+## Project Reference
+See: .planning/PROJECT.md (updated 2026-09-07)
+**Core value:** Each AIOStreams profile is a complete Jellyfin server for its owner.
+**Current focus:** Phase 1: Port
+
+## Position
+Phase 1 not started. Branch `jellyfin-layer` at v2.34.0 (e694b6ac), pushed.
+
+## Session log
+- 2026-09-07: project initialised after AioFin was discontinued.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,10 +3,11 @@
 ## Project Reference
 See: .planning/PROJECT.md (updated 2026-09-07)
 **Core value:** Each AIOStreams profile is a complete Jellyfin server for its owner.
-**Current focus:** Phase 1: Port
+**Current focus:** Phase 2: Parallel Deploy
 
 ## Position
-Phase 1 not started. Branch `jellyfin-layer` at v2.34.0 (e694b6ac), pushed.
+Phase 1 COMPLETE 2026-09-08 (commits 419aa27b..f6b355d8, all pushed). Layer mounted at `/jellyfin`; login = profile UUID + password; env `ENABLE_JELLYFIN_API`; migrations 0027/0028; deps ws/@types/ws. Next: Phase 2 — build image, push to GHCR (tweakapps), parallel container on Dubai VPS with DB copy + own hostname.
 
 ## Session log
 - 2026-09-07: project initialised after AioFin was discontinued.
+- 2026-09-08: Phase 1 port complete; Fable reviewed hook diff (additive only).

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -1,0 +1,52 @@
+{
+  "model_profile": "balanced",
+  "commit_docs": true,
+  "parallelization": false,
+  "search_gitignored": false,
+  "brave_search": false,
+  "firecrawl": false,
+  "exa_search": false,
+  "git": {
+    "branching_strategy": "none",
+    "phase_branch_template": "gsd/phase-{phase}-{slug}",
+    "milestone_branch_template": "gsd/{milestone}-{slug}",
+    "quick_branch_template": null
+  },
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true,
+    "nyquist_validation": false,
+    "auto_advance": false,
+    "node_repair": true,
+    "node_repair_budget": 2,
+    "ui_phase": true,
+    "ui_safety_gate": true,
+    "text_mode": false,
+    "research_before_questions": false,
+    "discuss_mode": "discuss",
+    "skip_discuss": false,
+    "code_review": true,
+    "code_review_depth": "standard",
+    "use_worktrees": false
+  },
+  "ship": {
+    "pr_body_sections": [
+      {
+        "heading": "Risks & Dependencies",
+        "enabled": true,
+        "source": "PLAN.md ## Risks || PLAN.md ## Dependencies",
+        "fallback": "- No known high-risk rollout dependencies."
+      }
+    ]
+  },
+  "hooks": {
+    "context_warnings": true
+  },
+  "project_code": null,
+  "phase_naming": "sequential",
+  "agent_skills": {},
+  "features": {},
+  "mode": "interactive",
+  "granularity": "coarse"
+}

--- a/.planning/phases/01-port/01-01-PLAN.md
+++ b/.planning/phases/01-port/01-01-PLAN.md
@@ -1,0 +1,32 @@
+---
+phase: 1
+plan: 01
+wave: 1
+depends_on: []
+autonomous: true
+requirements: [PORT-01, PORT-02, PORT-03, PORT-04]
+files_modified: [packages/core/src/jellyfin/**, packages/core/src/db/**, packages/server/src/routes/jellyfin/**, packages/server/src/app.ts, packages/server/src/server.ts, packages/core/src/index.ts, packages/core/src/config/schema/api.ts, packages/core/src/formatters/base.ts, packages/frontend/src/components/menu/save-install.tsx]
+---
+
+# Plan 01-01 — Port the qooode Jellyfin layer onto AIOStreams v2.34.0
+
+## Objective
+Bring the Jellyfin compatibility layer from `jflayer/main` (qooode/AIOStreams, a 2.33.x-dev snapshot) onto `jellyfin-layer` (upstream v2.34.0) as an additive patch: new files copied verbatim, core hooks re-applied minimally, everything building and tested. Push after every commit.
+
+## Method (locked)
+1. **Find the layer's true base.** `jflayer/main` has no history. Determine which upstream commit it was cut from: for the 50 non-jellyfin files that differ from v2.33.2, check whether they match some upstream commit between v2.33.2 and v2.34.0 (`git log v2.33.2..v2.34.0 --format=%h -- <file>` and compare blob hashes with `git rev-parse <commit>:<path>` vs `git rev-parse jflayer/main:<path>`). Pick the upstream commit `BASE` that matches the most files. Record it in the summary.
+2. **Extract the layer as a patch.** `git diff BASE jflayer/main -- <paths>` restricted to: everything matching `jellyfin` in the path, plus the hook files where the diff is jellyfin-related. For each non-jellyfin file that differs, keep ONLY hunks that reference jellyfin (route mount, migration registration, repository export, Installation>Jellyfin UI, config schema fields, formatter export). Drop all other hunks (they are BASE-vs-snapshot noise). Save the curated patch as `.planning/phases/01-port/jellyfin-layer.patch` (commit it — it documents the port).
+3. **Apply on v2.34.0.** `git apply --3way` the curated patch on `jellyfin-layer`. Resolve hook conflicts by re-applying the hook intent on the v2.34.0 version of the file (e.g. add the migration to the 2.34.0 migrations index in order after the last upstream migration; mount the router in 2.34.0's app.ts next to the stremio routes with the same rate-limiter names that exist in 2.34.0 — if a limiter the layer imports no longer exists, map it to the 2.34.0 equivalent and note it).
+4. **Build & test.** `pnpm install --frozen-lockfile` (if the layer added dependencies, add them to the right package and regenerate the lockfile; note them), `pnpm build`, then `pnpm -r test` (or the repo's test script). The three layer tests must pass; upstream tests must be no worse than on a clean v2.34.0 (run the suite once on v2.34.0 first if needed to establish the baseline count).
+5. **Migrations on a DB copy.** If a local sqlite/postgres dev DB can be created by the repo (check `packages/server` env docs; default is sqlite), start the server locally with a temp data dir, confirm migrations `0020_jellyfin` and `0021_jellyfin_keys` run and the `jellyfin_playstate` table exists.
+6. **Local smoke.** With the local server running, create/load a profile (the repo's own way — e.g. via the configure UI or API with a throwaway password), then `POST /jellyfin/Users/AuthenticateByName` (find the actual mount path in the ported router) with `{Username:<uuid>, Pw:<password>}` → expect 200 with `AccessToken`; `GET /jellyfin/System/Info/Public` → 200. Record the mount path.
+7. **Commits (each pushed to origin):** `feat(jellyfin): add Jellyfin compatibility layer files from qooode/AIOStreams` (new files only), `feat(jellyfin): wire layer into v2.34.0 (routes, migrations, repositories, config, UI)` (hooks), `chore(jellyfin): deps/lockfile` if needed, `docs(01-01): port summary + curated patch`.
+
+## Acceptance criteria
+- `git diff v2.34.0..jellyfin-layer --stat` shows only jellyfin files + the hook files + lockfile/package.json + .planning
+- `pnpm build` exit 0; layer tests 3/3; upstream suite ≥ baseline
+- `jellyfin_playstate` table present after local start; login returns a token; mount path recorded
+- Summary ≤25 lines at `.planning/phases/01-port/01-01-SUMMARY.md` with BASE commit, hook list, deps, test counts, mount path, and anything from the layer that could not be ported
+
+## Hard rules
+- No edits to upstream files beyond the hooks. No secrets committed (throwaway local profile only). Never touch the Dubai VPS in this plan. Push after every commit (`git push origin jellyfin-layer`).

--- a/.planning/phases/01-port/01-01-SUMMARY.md
+++ b/.planning/phases/01-port/01-01-SUMMARY.md
@@ -1,0 +1,19 @@
+# Plan 01-01 Summary — Port qooode Jellyfin layer onto v2.34.0
+
+**BASE commit** (jflayer/main's true parent): `04b3d736e5b5bfb943bb1b85548a9ef1abf02ad2` ("style: format", 2026-08-24) — matched 32/55 non-jellyfin file blobs, the strongest single-commit match.
+
+**New files ported verbatim (21):** `core/src/jellyfin/{dto,ids,ids-codec,ids.test,images,images.test,index,service}.ts`, `core/src/db/repositories/jellyfin.ts`, migrations (renumbered 0020/0021 → **0027/0028**, upstream already occupies 0020–0026), `server/src/routes/jellyfin/{index,context,items,library,playback,system,tasks,ws,relay-target,relay-target.test}.ts`.
+
+**Hooks re-applied:** `config/schema/api.ts` (4 new settings), `db/index.ts` (+export), `db/migrations/index.ts` (register 0027/0028), `db/repositories/users.ts` (+`verifyCredentials`), `core/index.ts` (+export), `server/app.ts` (+3 route mounts, no limiter renames needed), `server/express.d.ts` (+2 fields), `server/server.ts` (+registerJellyfinTasks/attachJellyfinWebSocket), `frontend/save-install.tsx` (Jellyfin install card). **`formatters/base.ts` intentionally untouched** — its only diff vs jflayer was unrelated upstream drift (`mediaInfoQuality`), not a jellyfin hook.
+
+**Deps added:** `ws@^8.21.0` + `@types/ws@^8.18.1` in `packages/server/package.json` (ws.ts needs it; missed by the literal-jellyfin-grep pass, caught at build time).
+
+**Deviations (Rule 1/3 auto-fixes):** ported `utils/concurrency.ts` (+test) — `library.ts` imports `collectConcurrent` from core, not exported on v2.34.0; fixed one implicit-any TS7006 in `library.ts`; `ids.test.ts`/`images.test.ts` briefly mis-converted to vitest then reverted — `packages/core` tests run via `tsx --test` (node:test), not vitest.
+
+**Tests:** core `50/50` pass (incl. layer: jellyfin id codec, jellyfin image memory, collectConcurrent); server `5/5` (relay-target); frontend `281/281` (pre-existing) — no regressions vs pre-patch state.
+
+**Build:** `pnpm build` exit 0 (crypto→core→server→frontend→seanime-extensions).
+
+**Local smoke:** sqlite temp DB, migrations 1–28 applied, `jellyfin_playstate`/`jellyfin_items`/`jellyfin_display_prefs` tables confirmed. Mount path: **`/jellyfin`**. `POST /jellyfin/Users/AuthenticateByName` → 200 + `AccessToken`. `GET /jellyfin/System/Info/Public` → 200.
+
+**Gaps:** none — every jellyfin route/hook ported and verified; docs mdx env-var table not updated (out of `files_modified` scope).

--- a/.planning/phases/01-port/jellyfin-layer.patch
+++ b/.planning/phases/01-port/jellyfin-layer.patch
@@ -1,0 +1,6546 @@
+diff --git a/packages/core/src/db/migrations/0020_jellyfin.ts b/packages/core/src/db/migrations/0020_jellyfin.ts
+new file mode 100644
+index 00000000..9dd58c49
+--- /dev/null
++++ b/packages/core/src/db/migrations/0020_jellyfin.ts
+@@ -0,0 +1,74 @@
++import type { Migration } from './types.js';
++
++export const jellyfin: Migration = {
++  id: 20,
++  name: 'jellyfin',
++  up: {
++    sqlite: `
++      CREATE TABLE IF NOT EXISTS jellyfin_items (
++        id          TEXT PRIMARY KEY,
++        payload     TEXT NOT NULL,
++        created_at  INTEGER NOT NULL DEFAULT 0
++      );
++
++      CREATE TABLE IF NOT EXISTS jellyfin_playstate (
++        uuid             TEXT NOT NULL REFERENCES users(uuid) ON DELETE CASCADE,
++        item_id          TEXT NOT NULL,
++        payload          TEXT NOT NULL,
++        position_ticks   INTEGER NOT NULL DEFAULT 0,
++        runtime_ticks    INTEGER NOT NULL DEFAULT 0,
++        played           INTEGER NOT NULL DEFAULT 0,
++        play_count       INTEGER NOT NULL DEFAULT 0,
++        favorite         INTEGER NOT NULL DEFAULT 0,
++        last_played_at   INTEGER,
++        updated_at       INTEGER NOT NULL DEFAULT 0,
++        PRIMARY KEY (uuid, item_id)
++      );
++
++      CREATE INDEX IF NOT EXISTS idx_jellyfin_playstate_uuid_updated
++        ON jellyfin_playstate (uuid, updated_at DESC);
++
++      CREATE TABLE IF NOT EXISTS jellyfin_display_prefs (
++        uuid        TEXT NOT NULL REFERENCES users(uuid) ON DELETE CASCADE,
++        pref_id     TEXT NOT NULL,
++        client      TEXT NOT NULL,
++        payload     TEXT NOT NULL,
++        updated_at  INTEGER NOT NULL DEFAULT 0,
++        PRIMARY KEY (uuid, pref_id, client)
++      );
++    `,
++    postgres: `
++      CREATE TABLE IF NOT EXISTS jellyfin_items (
++        id          TEXT PRIMARY KEY,
++        payload     TEXT NOT NULL,
++        created_at  BIGINT NOT NULL DEFAULT 0
++      );
++
++      CREATE TABLE IF NOT EXISTS jellyfin_playstate (
++        uuid             TEXT NOT NULL REFERENCES users(uuid) ON DELETE CASCADE,
++        item_id          TEXT NOT NULL,
++        payload          TEXT NOT NULL,
++        position_ticks   BIGINT NOT NULL DEFAULT 0,
++        runtime_ticks    BIGINT NOT NULL DEFAULT 0,
++        played           INTEGER NOT NULL DEFAULT 0,
++        play_count       INTEGER NOT NULL DEFAULT 0,
++        favorite         INTEGER NOT NULL DEFAULT 0,
++        last_played_at   BIGINT,
++        updated_at       BIGINT NOT NULL DEFAULT 0,
++        PRIMARY KEY (uuid, item_id)
++      );
++
++      CREATE INDEX IF NOT EXISTS idx_jellyfin_playstate_uuid_updated
++        ON jellyfin_playstate (uuid, updated_at DESC);
++
++      CREATE TABLE IF NOT EXISTS jellyfin_display_prefs (
++        uuid        TEXT NOT NULL REFERENCES users(uuid) ON DELETE CASCADE,
++        pref_id     TEXT NOT NULL,
++        client      TEXT NOT NULL,
++        payload     TEXT NOT NULL,
++        updated_at  BIGINT NOT NULL DEFAULT 0,
++        PRIMARY KEY (uuid, pref_id, client)
++      );
++    `,
++  },
++};
+diff --git a/packages/core/src/db/migrations/0021_jellyfin_keys.ts b/packages/core/src/db/migrations/0021_jellyfin_keys.ts
+new file mode 100644
+index 00000000..83852fc6
+--- /dev/null
++++ b/packages/core/src/db/migrations/0021_jellyfin_keys.ts
+@@ -0,0 +1,34 @@
++import type { Migration } from './types.js';
++
++export const jellyfinKeys: Migration = {
++  id: 21,
++  name: 'jellyfin_keys',
++  up: {
++    sqlite: `
++      ALTER TABLE jellyfin_playstate ADD COLUMN series_key TEXT;
++
++      UPDATE jellyfin_playstate
++         SET series_key = json_extract(payload, '$.t') || '|' || json_extract(payload, '$.i')
++       WHERE json_extract(payload, '$.k') = 'episode';
++
++      CREATE INDEX IF NOT EXISTS idx_jellyfin_playstate_series
++        ON jellyfin_playstate (uuid, series_key);
++
++      CREATE INDEX IF NOT EXISTS idx_jellyfin_items_created
++        ON jellyfin_items (created_at);
++    `,
++    postgres: `
++      ALTER TABLE jellyfin_playstate ADD COLUMN IF NOT EXISTS series_key TEXT;
++
++      UPDATE jellyfin_playstate
++         SET series_key = (payload::jsonb ->> 't') || '|' || (payload::jsonb ->> 'i')
++       WHERE payload::jsonb ->> 'k' = 'episode';
++
++      CREATE INDEX IF NOT EXISTS idx_jellyfin_playstate_series
++        ON jellyfin_playstate (uuid, series_key);
++
++      CREATE INDEX IF NOT EXISTS idx_jellyfin_items_created
++        ON jellyfin_items (created_at);
++    `,
++  },
++};
+diff --git a/packages/core/src/db/repositories/jellyfin.ts b/packages/core/src/db/repositories/jellyfin.ts
+new file mode 100644
+index 00000000..6d3428af
+--- /dev/null
++++ b/packages/core/src/db/repositories/jellyfin.ts
+@@ -0,0 +1,324 @@
++import { getDb } from '../db.js';
++import { join, sql } from '../sql.js';
++
++export type JellyfinItemDescriptor =
++  | { k: 'view'; t: string; c: string }
++  | { k: 'genre'; t: string; c: string; g: string }
++  | { k: 'movie'; t: string; i: string }
++  | { k: 'series'; t: string; i: string }
++  | { k: 'season'; t: string; i: string; s: number }
++  | { k: 'episode'; t: string; i: string; s: number; e: number; v: string }
++  | { k: 'person'; n: string }
++  | { k: 'studio'; n: string };
++
++export interface JellyfinPlaystateRow {
++  itemId: string;
++  payload: JellyfinItemDescriptor;
++  positionTicks: number;
++  runtimeTicks: number;
++  played: boolean;
++  playCount: number;
++  favorite: boolean;
++  lastPlayedAt: number | null;
++  updatedAt: number;
++}
++
++interface PlaystateDbRow {
++  item_id: string;
++  payload: string;
++  position_ticks: number | string;
++  runtime_ticks: number | string;
++  played: number | boolean;
++  play_count: number | string;
++  favorite: number | boolean;
++  last_played_at: number | string | null;
++  updated_at: number | string;
++  [k: string]: unknown;
++}
++
++function toPlaystate(r: PlaystateDbRow): JellyfinPlaystateRow {
++  return {
++    itemId: r.item_id,
++    payload: JSON.parse(r.payload),
++    positionTicks: Number(r.position_ticks),
++    runtimeTicks: Number(r.runtime_ticks),
++    played: Boolean(Number(r.played)),
++    playCount: Number(r.play_count),
++    favorite: Boolean(Number(r.favorite)),
++    lastPlayedAt: r.last_played_at == null ? null : Number(r.last_played_at),
++    updatedAt: Number(r.updated_at),
++  };
++}
++
++const CHUNK = 200;
++
++function seriesKeyFor(d: JellyfinItemDescriptor): string | null {
++  return d.k === 'episode' ? `${d.t}|${d.i}` : null;
++}
++
++export class JellyfinRepository {
++  static async userVersions(uuids: string[]): Promise<Map<string, string>> {
++    const out = new Map<string, string>();
++    const wanted = [...new Set(uuids.filter(Boolean))];
++    if (!wanted.length) return out;
++    const rows = await getDb().query<{
++      uuid: string;
++      updated_at: string | Date | null;
++    }>(
++      sql`SELECT uuid, updated_at FROM users
++           WHERE uuid IN (${join(wanted.map((u) => sql`${u}`))})`
++    );
++    for (const r of rows) {
++      out.set(
++        r.uuid,
++        r.updated_at instanceof Date
++          ? r.updated_at.toISOString()
++          : String(r.updated_at ?? '')
++      );
++    }
++    return out;
++  }
++
++  static async rememberItems(
++    entries: { id: string; payload: JellyfinItemDescriptor }[]
++  ): Promise<void> {
++    if (!entries.length) return;
++    const now = Date.now();
++    for (let i = 0; i < entries.length; i += CHUNK) {
++      const slice = entries.slice(i, i + CHUNK);
++      const values = join(
++        slice.map((e) => sql`(${e.id}, ${JSON.stringify(e.payload)}, ${now})`)
++      );
++      await getDb().exec(
++        sql`INSERT INTO jellyfin_items (id, payload, created_at)
++            VALUES ${values}
++            ON CONFLICT(id) DO NOTHING`
++      );
++    }
++  }
++
++  static async lookupItem(id: string): Promise<JellyfinItemDescriptor | null> {
++    const row = await getDb().maybeOne<{ payload: string }>(
++      sql`SELECT payload FROM jellyfin_items WHERE id = ${id}`
++    );
++    return row ? (JSON.parse(row.payload) as JellyfinItemDescriptor) : null;
++  }
++
++  static async getPlaystates(
++    uuid: string,
++    itemIds: string[]
++  ): Promise<Map<string, JellyfinPlaystateRow>> {
++    const out = new Map<string, JellyfinPlaystateRow>();
++    if (!itemIds.length) return out;
++    for (let i = 0; i < itemIds.length; i += CHUNK) {
++      const slice = itemIds.slice(i, i + CHUNK);
++      const rows = await getDb().query<PlaystateDbRow>(
++        sql`SELECT * FROM jellyfin_playstate
++             WHERE uuid = ${uuid} AND item_id IN (${join(slice.map((id) => sql`${id}`))})`
++      );
++      for (const r of rows) out.set(r.item_id, toPlaystate(r));
++    }
++    return out;
++  }
++
++  static async getPlaystate(
++    uuid: string,
++    itemId: string
++  ): Promise<JellyfinPlaystateRow | null> {
++    const row = await getDb().maybeOne<PlaystateDbRow>(
++      sql`SELECT * FROM jellyfin_playstate WHERE uuid = ${uuid} AND item_id = ${itemId}`
++    );
++    return row ? toPlaystate(row) : null;
++  }
++
++  static async upsertPlaystate(
++    uuid: string,
++    itemId: string,
++    payload: JellyfinItemDescriptor,
++    patch: {
++      positionTicks?: number;
++      runtimeTicks?: number;
++      played?: boolean;
++      incrementPlayCount?: boolean | 'if-unplayed';
++      favorite?: boolean;
++      lastPlayedAt?: number | null;
++    }
++  ): Promise<JellyfinPlaystateRow> {
++    const now = Date.now();
++    const pos = patch.positionTicks ?? null;
++    const rt = patch.runtimeTicks ?? null;
++    const played = patch.played == null ? null : patch.played ? 1 : 0;
++    const fav = patch.favorite == null ? null : patch.favorite ? 1 : 0;
++    const incMode =
++      patch.incrementPlayCount === 'if-unplayed'
++        ? 2
++        : patch.incrementPlayCount
++          ? 1
++          : 0;
++    const setLastPlayed = patch.lastPlayedAt === undefined ? 0 : 1;
++    const lastPlayed = patch.lastPlayedAt ?? null;
++    const seriesKey = seriesKeyFor(payload);
++    await getDb().exec(
++      sql`INSERT INTO jellyfin_playstate
++            (uuid, item_id, payload, series_key, position_ticks, runtime_ticks, played, play_count, favorite, last_played_at, updated_at)
++          VALUES (${uuid}, ${itemId}, ${JSON.stringify(payload)}, ${seriesKey},
++                  COALESCE(${pos}, 0), COALESCE(${rt}, 0), COALESCE(${played}, 0),
++                  CASE WHEN ${incMode} > 0 THEN 1 ELSE 0 END,
++                  COALESCE(${fav}, 0), ${lastPlayed}, ${now})
++          ON CONFLICT(uuid, item_id) DO UPDATE SET
++            payload = excluded.payload,
++            series_key = excluded.series_key,
++            position_ticks = COALESCE(${pos}, jellyfin_playstate.position_ticks),
++            runtime_ticks = COALESCE(${rt}, jellyfin_playstate.runtime_ticks),
++            played = COALESCE(${played}, jellyfin_playstate.played),
++            play_count = jellyfin_playstate.play_count +
++              CASE ${incMode}
++                WHEN 1 THEN 1
++                WHEN 2 THEN CASE WHEN jellyfin_playstate.played = 1 THEN 0 ELSE 1 END
++                ELSE 0
++              END,
++            favorite = COALESCE(${fav}, jellyfin_playstate.favorite),
++            last_played_at = CASE WHEN ${setLastPlayed} = 1 THEN ${lastPlayed} ELSE jellyfin_playstate.last_played_at END,
++            updated_at = excluded.updated_at`
++    );
++    const row = await this.getPlaystate(uuid, itemId);
++    if (row) return row;
++    return {
++      itemId,
++      payload,
++      positionTicks: pos ?? 0,
++      runtimeTicks: rt ?? 0,
++      played: !!played,
++      playCount: incMode > 0 ? 1 : 0,
++      favorite: !!fav,
++      lastPlayedAt: lastPlayed,
++      updatedAt: now,
++    };
++  }
++
++  static async deletePlaystate(uuid: string, itemId: string): Promise<void> {
++    await getDb().exec(
++      sql`DELETE FROM jellyfin_playstate WHERE uuid = ${uuid} AND item_id = ${itemId}`
++    );
++  }
++
++  static async listResume(
++    uuid: string,
++    limit: number,
++    kinds: string[] = ['movie', 'episode']
++  ): Promise<JellyfinPlaystateRow[]> {
++    const rows = await getDb().query<PlaystateDbRow>(
++      sql`SELECT * FROM jellyfin_playstate
++           WHERE uuid = ${uuid} AND played = 0 AND position_ticks > 0
++           ORDER BY updated_at DESC
++           LIMIT ${Math.max(limit * 3, 30)}`
++    );
++    return rows
++      .map(toPlaystate)
++      .filter((r) => kinds.includes(r.payload.k))
++      .slice(0, limit);
++  }
++
++  static async listRecentEpisodesBySeries(
++    uuid: string,
++    limit: number
++  ): Promise<JellyfinPlaystateRow[]> {
++    const rows = await getDb().query<PlaystateDbRow>(
++      sql`SELECT * FROM jellyfin_playstate
++           WHERE uuid = ${uuid} AND (played = 1 OR position_ticks > 0)
++           ORDER BY updated_at DESC
++           LIMIT 500`
++    );
++    const seen = new Set<string>();
++    const out: JellyfinPlaystateRow[] = [];
++    for (const r of rows.map(toPlaystate)) {
++      if (r.payload.k !== 'episode') continue;
++      const key = `${r.payload.t}|${r.payload.i}`;
++      if (seen.has(key)) continue;
++      seen.add(key);
++      out.push(r);
++      if (out.length >= limit) break;
++    }
++    return out;
++  }
++
++  static async listFavorites(
++    uuid: string,
++    kinds?: string[]
++  ): Promise<JellyfinPlaystateRow[]> {
++    const rows = await getDb().query<PlaystateDbRow>(
++      sql`SELECT * FROM jellyfin_playstate
++           WHERE uuid = ${uuid} AND favorite = 1
++           ORDER BY updated_at DESC
++           LIMIT 500`
++    );
++    return rows
++      .map(toPlaystate)
++      .filter((r) => !kinds || kinds.includes(r.payload.k));
++  }
++
++  static async listPlayed(
++    uuid: string,
++    kinds?: string[]
++  ): Promise<JellyfinPlaystateRow[]> {
++    const rows = await getDb().query<PlaystateDbRow>(
++      sql`SELECT * FROM jellyfin_playstate
++           WHERE uuid = ${uuid} AND played = 1
++           ORDER BY updated_at DESC
++           LIMIT 500`
++    );
++    return rows
++      .map(toPlaystate)
++      .filter((r) => !kinds || kinds.includes(r.payload.k));
++  }
++
++  static async listForSeries(
++    uuid: string,
++    type: string,
++    seriesId: string
++  ): Promise<JellyfinPlaystateRow[]> {
++    const rows = await getDb().query<PlaystateDbRow>(
++      sql`SELECT * FROM jellyfin_playstate
++           WHERE uuid = ${uuid} AND series_key = ${`${type}|${seriesId}`}`
++    );
++    return rows.map(toPlaystate).filter((r) => r.payload.k === 'episode');
++  }
++
++  static async pruneItems(maxAgeMs: number): Promise<number> {
++    const cutoff = Date.now() - maxAgeMs;
++    const res = await getDb().exec(
++      sql`DELETE FROM jellyfin_items
++           WHERE created_at < ${cutoff}
++             AND NOT EXISTS (
++               SELECT 1 FROM jellyfin_playstate p WHERE p.item_id = jellyfin_items.id
++             )`
++    );
++    return res.rowCount;
++  }
++
++  static async getDisplayPrefs(
++    uuid: string,
++    prefId: string,
++    client: string
++  ): Promise<Record<string, unknown> | null> {
++    const row = await getDb().maybeOne<{ payload: string }>(
++      sql`SELECT payload FROM jellyfin_display_prefs
++           WHERE uuid = ${uuid} AND pref_id = ${prefId} AND client = ${client}`
++    );
++    return row ? JSON.parse(row.payload) : null;
++  }
++
++  static async setDisplayPrefs(
++    uuid: string,
++    prefId: string,
++    client: string,
++    payload: Record<string, unknown>
++  ): Promise<void> {
++    await getDb().exec(
++      sql`INSERT INTO jellyfin_display_prefs (uuid, pref_id, client, payload, updated_at)
++          VALUES (${uuid}, ${prefId}, ${client}, ${JSON.stringify(payload)}, ${Date.now()})
++          ON CONFLICT(uuid, pref_id, client) DO UPDATE SET
++            payload = excluded.payload, updated_at = excluded.updated_at`
++    );
++  }
++}
+diff --git a/packages/core/src/jellyfin/dto.ts b/packages/core/src/jellyfin/dto.ts
+new file mode 100644
+index 00000000..cca23a0f
+--- /dev/null
++++ b/packages/core/src/jellyfin/dto.ts
+@@ -0,0 +1,1088 @@
++import type {
++  Manifest,
++  Meta,
++  MetaPreview,
++  ParsedMeta,
++  ParsedStream,
++  Subtitle,
++} from '../db/schemas.js';
++import type {
++  JellyfinItemDescriptor,
++  JellyfinPlaystateRow,
++} from '../db/repositories/jellyfin.js';
++import { IdParser } from '../utils/id-parser.js';
++import { languageToCode } from '../utils/languages.js';
++import { encodeJellyfinId, imageTag, streamIdToMediaSourceId } from './ids.js';
++import { rememberImages, type ItemImages } from './images.js';
++
++export const TICKS_PER_MS = 10_000;
++export const TICKS_PER_SECOND = 10_000_000;
++export const TICKS_PER_MINUTE = 600_000_000;
++
++export type JellyfinItemType =
++  | 'Movie'
++  | 'Series'
++  | 'Season'
++  | 'Episode'
++  | 'CollectionFolder'
++  | 'Folder'
++  | 'Genre'
++  | 'Person'
++  | 'Studio'
++  | 'Video';
++
++export type JellyfinUserItemData = {
++  PlaybackPositionTicks: number;
++  PlayCount: number;
++  IsFavorite: boolean;
++  Played: boolean;
++  LastPlayedDate?: string;
++  PlayedPercentage?: number;
++  UnplayedItemCount?: number;
++  Key: string;
++  ItemId: string;
++};
++
++export type JellyfinItem = {
++  Id: string;
++  Name: string;
++  ServerId: string;
++  Type: JellyfinItemType;
++  IsFolder: boolean;
++  [key: string]: unknown;
++};
++
++export type JellyfinMediaStream = {
++  Type: 'Video' | 'Audio' | 'Subtitle';
++  Index: number;
++  Codec?: string;
++  Language?: string;
++  DisplayTitle?: string;
++  IsDefault?: boolean;
++  IsForced?: boolean;
++  IsExternal?: boolean;
++  [key: string]: unknown;
++};
++
++export type JellyfinMediaSource = {
++  Id: string;
++  Name: string;
++  Path: string;
++  Protocol: 'Http' | 'File';
++  [key: string]: unknown;
++};
++
++export interface ItemBuildContext {
++  uuid: string;
++  serverId: string;
++}
++
++export function parseRuntimeToTicks(
++  runtime: string | number | null | undefined
++): number | undefined {
++  if (runtime == null) return undefined;
++  if (typeof runtime === 'number') return runtime * TICKS_PER_MINUTE;
++  const s = runtime.toLowerCase();
++  let minutes = 0;
++  const h = s.match(/(\d+)\s*h/);
++  const m = s.match(/(\d+)\s*m/);
++  if (h) minutes += Number(h[1]) * 60;
++  if (m) minutes += Number(m[1]);
++  if (!h && !m) {
++    const n = s.match(/(\d+)/);
++    if (n) minutes = Number(n[1]);
++  }
++  return minutes > 0 ? minutes * TICKS_PER_MINUTE : undefined;
++}
++
++function parseYear(value: unknown): number | undefined {
++  if (value == null) return undefined;
++  const m = String(value).match(/(\d{4})/);
++  return m ? Number(m[1]) : undefined;
++}
++
++function parseReleaseStatus(
++  value: unknown
++): 'Continuing' | 'Ended' | undefined {
++  if (value == null) return undefined;
++  const s = String(value);
++  if (/\d{4}\s*[-–]\s*$/.test(s)) return 'Continuing';
++  if (/\d{4}\s*[-–]\s*\d{4}/.test(s)) return 'Ended';
++  return undefined;
++}
++
++function toIso(date: unknown): string | undefined {
++  if (!date) return undefined;
++  const d = new Date(String(date));
++  return isNaN(d.getTime()) ? undefined : d.toISOString();
++}
++
++function numberOr(value: unknown): number | undefined {
++  if (value == null || value === '') return undefined;
++  const n = Number(value);
++  return Number.isFinite(n) ? n : undefined;
++}
++
++function linksByCategory(meta: MetaPreview | Meta, category: string): string[] {
++  return (meta.links ?? [])
++    .filter((l) => l.category.toLowerCase() === category.toLowerCase())
++    .map((l) => l.name);
++}
++
++export function providerIdsFor(
++  meta: MetaPreview | Meta | { id: string; type: string }
++): Record<string, string> {
++  const out: Record<string, string> = {};
++  const parsed = IdParser.parse(meta.id, meta.type);
++  if (parsed) {
++    const v = String(parsed.value);
++    switch (parsed.type) {
++      case 'imdbId':
++        out.Imdb = v.startsWith('tt') ? v : `tt${v}`;
++        break;
++      case 'themoviedbId':
++        out.Tmdb = v;
++        break;
++      case 'thetvdbId':
++        out.Tvdb = v;
++        break;
++      case 'kitsuId':
++        out.Kitsu = v;
++        break;
++      case 'malId':
++        out.MyAnimeList = v;
++        break;
++      case 'anilistId':
++        out.AniList = v;
++        break;
++      case 'anidbId':
++        out.AniDB = v;
++        break;
++      case 'simklId':
++        out.Simkl = v;
++        break;
++    }
++  }
++  const any = meta as Record<string, unknown>;
++  if (typeof any.imdb_id === 'string' && !out.Imdb) out.Imdb = any.imdb_id;
++  if (any.moviedb_id != null && !out.Tmdb) out.Tmdb = String(any.moviedb_id);
++  if (any.tmdb_id != null && !out.Tmdb) out.Tmdb = String(any.tmdb_id);
++  if (any.tvdb_id != null && !out.Tvdb) out.Tvdb = String(any.tvdb_id);
++  if (any.kitsu_id != null && !out.Kitsu) out.Kitsu = String(any.kitsu_id);
++  if (any.mal_id != null && !out.MyAnimeList)
++    out.MyAnimeList = String(any.mal_id);
++  if (any.anilist_id != null && !out.AniList)
++    out.AniList = String(any.anilist_id);
++  const ids = any.ids ?? any.externalIds;
++  if (ids && typeof ids === 'object') {
++    const rec = ids as Record<string, unknown>;
++    const map: Record<string, string> = {
++      imdb: 'Imdb',
++      imdb_id: 'Imdb',
++      tmdb: 'Tmdb',
++      tmdb_id: 'Tmdb',
++      tvdb: 'Tvdb',
++      tvdb_id: 'Tvdb',
++      kitsu: 'Kitsu',
++      mal: 'MyAnimeList',
++      anilist: 'AniList',
++      anidb: 'AniDB',
++    };
++    for (const [k, jk] of Object.entries(map)) {
++      if (rec[k] != null && !out[jk]) out[jk] = String(rec[k]);
++    }
++  }
++  return out;
++}
++
++function externalUrls(providerIds: Record<string, string>) {
++  const urls: { Name: string; Url: string }[] = [];
++  if (providerIds.Imdb)
++    urls.push({
++      Name: 'IMDb',
++      Url: `https://www.imdb.com/title/${providerIds.Imdb}`,
++    });
++  if (providerIds.Tmdb)
++    urls.push({
++      Name: 'TheMovieDb',
++      Url: `https://www.themoviedb.org/search?query=${providerIds.Tmdb}`,
++    });
++  if (providerIds.MyAnimeList)
++    urls.push({
++      Name: 'MyAnimeList',
++      Url: `https://myanimelist.net/anime/${providerIds.MyAnimeList}`,
++    });
++  if (providerIds.AniList)
++    urls.push({
++      Name: 'AniList',
++      Url: `https://anilist.co/anime/${providerIds.AniList}`,
++    });
++  if (providerIds.Kitsu)
++    urls.push({
++      Name: 'Kitsu',
++      Url: `https://kitsu.app/anime/${providerIds.Kitsu}`,
++    });
++  return urls;
++}
++
++export function defaultUserData(itemId: string): JellyfinUserItemData {
++  return {
++    PlaybackPositionTicks: 0,
++    PlayCount: 0,
++    IsFavorite: false,
++    Played: false,
++    Key: itemId,
++    ItemId: itemId,
++  };
++}
++
++export function playstateToUserData(
++  itemId: string,
++  row: JellyfinPlaystateRow | undefined,
++  runtimeTicks?: number
++): JellyfinUserItemData {
++  if (!row) return defaultUserData(itemId);
++  const rt = runtimeTicks || row.runtimeTicks;
++  const ud: JellyfinUserItemData = {
++    PlaybackPositionTicks: row.played ? 0 : row.positionTicks,
++    PlayCount: row.playCount,
++    IsFavorite: row.favorite,
++    Played: row.played,
++    Key: itemId,
++    ItemId: itemId,
++  };
++  if (row.lastPlayedAt)
++    ud.LastPlayedDate = new Date(row.lastPlayedAt).toISOString();
++  if (!row.played && rt && row.positionTicks > 0)
++    ud.PlayedPercentage = Math.min(100, (row.positionTicks / rt) * 100);
++  return ud;
++}
++
++export function stremioTypeToItemType(type: string): 'Movie' | 'Series' {
++  return type === 'movie' ? 'Movie' : 'Series';
++}
++
++export function collectionTypeFor(type: string): string | undefined {
++  if (type === 'movie') return 'movies';
++  if (type === 'series' || type === 'anime') return 'tvshows';
++  if (type === 'tv' || type === 'channel') return 'livetv';
++  return undefined;
++}
++
++function peopleFrom(meta: MetaPreview | Meta) {
++  const people: { Name: string; Id: string; Type: string; Role?: string }[] =
++    [];
++  const push = (name: string, type: string) => {
++    if (!name) return;
++    people.push({
++      Name: name,
++      Id: encodeJellyfinId({ k: 'person', n: name }),
++      Type: type,
++    });
++  };
++  const castList = Array.isArray(meta.cast)
++    ? meta.cast
++    : linksByCategory(meta, 'Cast');
++  castList.forEach((c) => push(c, 'Actor'));
++  const directors = Array.isArray(meta.director)
++    ? meta.director.filter((d): d is string => typeof d === 'string')
++    : typeof meta.director === 'string'
++      ? [meta.director]
++      : linksByCategory(meta, 'Directors');
++  directors.forEach((d) => push(d, 'Director'));
++  linksByCategory(meta, 'Writers').forEach((w) => push(w, 'Writer'));
++  return people;
++}
++
++function genresFrom(meta: MetaPreview | Meta): string[] {
++  const g =
++    Array.isArray(meta.genres) && meta.genres.length
++      ? meta.genres
++      : linksByCategory(meta, 'Genres');
++  return [
++    ...new Set(
++      g.filter((x): x is string => typeof x === 'string' && x.length > 0)
++    ),
++  ];
++}
++
++function trailersFrom(meta: MetaPreview | Meta) {
++  return (meta.trailers ?? [])
++    .filter((t) => t.source)
++    .map((t) => ({
++      Name: t.type ?? 'Trailer',
++      Url: t.source.startsWith('http')
++        ? t.source
++        : `https://www.youtube.com/watch?v=${t.source}`,
++    }));
++}
++
++export function stubMediaSources(
++  itemId: string,
++  name: string
++): JellyfinMediaSource[] {
++  return [
++    {
++      Id: itemId,
++      ETag: itemId,
++      Name: name,
++      Path: `/aiostreams/${itemId}`,
++      Protocol: 'File',
++      Type: 'Default',
++      SupportsDirectPlay: true,
++      SupportsDirectStream: true,
++      SupportsTranscoding: false,
++      MediaStreams: [],
++      Formats: [],
++    },
++    {
++      Id: streamIdToMediaSourceId(`${itemId}-stub2`),
++      ETag: itemId,
++      Name: `${name} (2)`,
++      Path: `/aiostreams/${itemId}`,
++      Protocol: 'File',
++      Type: 'Default',
++      SupportsDirectPlay: true,
++      SupportsDirectStream: true,
++      SupportsTranscoding: false,
++      MediaStreams: [],
++      Formats: [],
++    },
++  ];
++}
++
++export function buildViewItem(
++  ctx: ItemBuildContext,
++  catalog: NonNullable<Manifest['catalogs']>[number]
++): JellyfinItem {
++  const id = encodeJellyfinId({ k: 'view', t: catalog.type, c: catalog.id });
++  const collectionType = collectionTypeFor(catalog.type);
++  return {
++    Id: id,
++    Name: catalog.name,
++    ServerId: ctx.serverId,
++    Type: 'CollectionFolder',
++    IsFolder: true,
++    ...(collectionType ? { CollectionType: collectionType } : {}),
++    Etag: imageTag(`${catalog.type}:${catalog.id}`),
++    DateCreated: '2020-01-01T00:00:00.0000000Z',
++    CanDelete: false,
++    CanDownload: false,
++    SortName: catalog.name.toLowerCase(),
++    ChildCount: 0,
++    DisplayPreferencesId: id,
++    LocationType: 'FileSystem',
++    PlayAccess: 'Full',
++    ImageTags: {},
++    BackdropImageTags: [],
++    UserData: defaultUserData(id),
++    Path: `/${catalog.type}/${catalog.id}`,
++    PrimaryImageAspectRatio: 1.7777,
++    ExtraType: undefined,
++    _aio: {
++      type: catalog.type,
++      catalogId: catalog.id,
++      extras: (catalog.extra ?? []).map((e) => e.name),
++    },
++  };
++}
++
++export function stripInternal(item: JellyfinItem): JellyfinItem {
++  const { _aio, ...rest } = item as JellyfinItem & { _aio?: unknown };
++  return rest as JellyfinItem;
++}
++
++export function buildGenreItem(
++  ctx: ItemBuildContext,
++  type: string,
++  catalogId: string,
++  genre: string
++): JellyfinItem {
++  const id = encodeJellyfinId({ k: 'genre', t: type, c: catalogId, g: genre });
++  return {
++    Id: id,
++    Name: genre,
++    ServerId: ctx.serverId,
++    Type: 'Genre',
++    IsFolder: true,
++    ImageTags: {},
++    BackdropImageTags: [],
++    UserData: defaultUserData(id),
++  };
++}
++
++export function buildPersonItem(
++  ctx: ItemBuildContext,
++  name: string
++): JellyfinItem {
++  const id = encodeJellyfinId({ k: 'person', n: name });
++  return {
++    Id: id,
++    Name: name,
++    ServerId: ctx.serverId,
++    Type: 'Person',
++    IsFolder: false,
++    ImageTags: {},
++    BackdropImageTags: [],
++    UserData: defaultUserData(id),
++  };
++}
++
++export function descriptorForMeta(meta: {
++  id: string;
++  type: string;
++}): JellyfinItemDescriptor {
++  return stremioTypeToItemType(meta.type) === 'Movie'
++    ? { k: 'movie', t: meta.type, i: meta.id }
++    : { k: 'series', t: meta.type, i: meta.id };
++}
++
++export function buildMetaItem(
++  ctx: ItemBuildContext,
++  meta: MetaPreview | Meta,
++  opts: {
++    parentId?: string;
++    userData?: JellyfinPlaystateRow;
++    complete?: boolean;
++  } = {}
++): JellyfinItem {
++  const descriptor = descriptorForMeta(meta);
++  const id = encodeJellyfinId(descriptor);
++  const itemType = stremioTypeToItemType(meta.type);
++  const full = meta as Meta;
++  const providerIds = providerIdsFor(meta);
++  const genres = genresFrom(meta);
++  const runtimeTicks = parseRuntimeToTicks(full.runtime);
++  const year =
++    parseYear(meta.releaseInfo) ??
++    parseYear((meta as Record<string, unknown>).year) ??
++    parseYear((meta as Record<string, unknown>).released);
++  const premiere = toIso((meta as Record<string, unknown>).released);
++
++  const images: ItemImages = {};
++  if (meta.poster) images.Primary = meta.poster;
++  if (full.background) images.Backdrop = full.background;
++  if (full.logo) images.Logo = full.logo;
++  rememberImages(ctx.uuid, id, images, opts.complete === true);
++
++  const imageTags: Record<string, string> = {};
++  if (images.Primary) imageTags.Primary = imageTag(images.Primary);
++  if (images.Logo) imageTags.Logo = imageTag(images.Logo);
++
++  const item: JellyfinItem = {
++    Id: id,
++    Name: meta.name ?? meta.id,
++    OriginalTitle: meta.name ?? meta.id,
++    SortName: (meta.name ?? meta.id).toLowerCase(),
++    ServerId: ctx.serverId,
++    Type: itemType,
++    IsFolder: itemType === 'Series',
++    MediaType: itemType === 'Movie' ? 'Video' : undefined,
++    Etag: imageTag(id),
++    DateCreated: premiere ?? '2020-01-01T00:00:00.0000000Z',
++    CanDelete: false,
++    CanDownload: itemType === 'Movie',
++    LocationType: 'FileSystem',
++    PlayAccess: 'Full',
++    Overview: meta.description ?? undefined,
++    ProductionYear: year,
++    PremiereDate: premiere,
++    CommunityRating: numberOr(meta.imdbRating),
++    OfficialRating: (meta as Record<string, unknown>).certification as
++      | string
++      | undefined,
++    RunTimeTicks: runtimeTicks,
++    Genres: genres,
++    GenreItems: genres.map((g) => ({
++      Name: g,
++      Id: encodeJellyfinId({ k: 'genre', t: meta.type, c: '', g }),
++    })),
++    People: peopleFrom(meta),
++    Studios: [],
++    Tags: [],
++    Taglines: [],
++    ProviderIds: providerIds,
++    ExternalUrls: externalUrls(providerIds),
++    RemoteTrailers: trailersFrom(meta),
++    ImageTags: imageTags,
++    BackdropImageTags: images.Backdrop ? [imageTag(images.Backdrop)] : [],
++    ParentId: opts.parentId,
++    PrimaryImageAspectRatio:
++      meta.posterShape === 'landscape'
++        ? 1.7777
++        : meta.posterShape === 'square'
++          ? 1
++          : 0.6666,
++    VideoType: itemType === 'Movie' ? 'VideoFile' : undefined,
++    Status:
++      itemType === 'Series' ? parseReleaseStatus(meta.releaseInfo) : undefined,
++    EndDate: undefined,
++    ChildCount:
++      itemType === 'Series' ? full.videos?.length || undefined : undefined,
++    RecursiveItemCount:
++      itemType === 'Series' ? full.videos?.length || undefined : undefined,
++    UserData: playstateToUserData(id, opts.userData, runtimeTicks),
++    Path: `/${meta.type}/${meta.id}`,
++    Container: undefined,
++    MediaSources:
++      itemType === 'Movie'
++        ? stubMediaSources(id, meta.name ?? meta.id)
++        : undefined,
++    MediaStreams: undefined,
++    _aio: { descriptor },
++  };
++  if (full.language) item.PreferredMetadataLanguage = full.language;
++  if ((meta as Record<string, unknown>).country)
++    item.ProductionLocations = [
++      String((meta as Record<string, unknown>).country),
++    ];
++  if (full.website) item.HomePageUrl = full.website;
++  return item;
++}
++
++export interface SeasonGroup {
++  season: number;
++  name: string;
++  videos: NonNullable<ParsedMeta['videos']>;
++}
++
++export function groupSeasons(meta: ParsedMeta): SeasonGroup[] {
++  const videos = [...(meta.videos ?? [])];
++  if (videos.length === 0) {
++    return [
++      {
++        season: 1,
++        name: 'Season 1',
++        videos: [
++          {
++            id: meta.id,
++            title: meta.name ?? meta.id,
++            season: 1,
++            episode: 1,
++            released: (meta as Record<string, unknown>).released as
++              | string
++              | undefined,
++            thumbnail: meta.background ?? meta.poster ?? undefined,
++            overview: meta.description ?? undefined,
++          },
++        ],
++      },
++    ];
++  }
++  const numbered = videos.some((v) => typeof v.episode === 'number');
++  const groups = new Map<number, SeasonGroup>();
++  videos.forEach((v, idx) => {
++    const season = typeof v.season === 'number' ? v.season : 1;
++    if (!numbered) v.episode = idx + 1;
++    else if (typeof v.episode !== 'number') v.episode = idx + 1;
++    if (typeof v.season !== 'number') v.season = season;
++    let g = groups.get(season);
++    if (!g) {
++      g = {
++        season,
++        name: season === 0 ? 'Specials' : `Season ${season}`,
++        videos: [],
++      };
++      groups.set(season, g);
++    }
++    g.videos.push(v);
++  });
++  for (const g of groups.values()) {
++    g.videos.sort((a, b) => (a.episode ?? 0) - (b.episode ?? 0));
++  }
++  return [...groups.values()].sort((a, b) => {
++    if (a.season === 0) return 1;
++    if (b.season === 0) return -1;
++    return a.season - b.season;
++  });
++}
++
++export function buildSeasonItem(
++  ctx: ItemBuildContext,
++  meta: ParsedMeta,
++  seriesItem: JellyfinItem,
++  group: SeasonGroup,
++  playstates?: Map<string, JellyfinPlaystateRow>
++): JellyfinItem {
++  const id = encodeJellyfinId({
++    k: 'season',
++    t: meta.type,
++    i: meta.id,
++    s: group.season,
++  });
++  const images: ItemImages = {};
++  if (meta.poster) images.Primary = meta.poster;
++  if (meta.background) images.Backdrop = meta.background;
++  rememberImages(ctx.uuid, id, images, true);
++
++  let played = 0;
++  let inProgress = false;
++  if (playstates) {
++    for (const v of group.videos) {
++      const epId = encodeJellyfinId({
++        k: 'episode',
++        t: meta.type,
++        i: meta.id,
++        s: group.season,
++        e: v.episode ?? 0,
++        v: v.id,
++      });
++      const ps = playstates.get(epId);
++      if (ps?.played) played++;
++      else if (ps && ps.positionTicks > 0) inProgress = true;
++    }
++  }
++  const total = group.videos.length;
++  return {
++    Id: id,
++    Name: group.name,
++    SortName: String(group.season).padStart(4, '0'),
++    ServerId: ctx.serverId,
++    Type: 'Season',
++    IsFolder: true,
++    IndexNumber: group.season,
++    SeriesId: seriesItem.Id,
++    SeriesName: seriesItem.Name,
++    ParentId: seriesItem.Id,
++    ChildCount: total,
++    RecursiveItemCount: total,
++    LocationType: 'FileSystem',
++    PlayAccess: 'Full',
++    CanDelete: false,
++    CanDownload: false,
++    ImageTags: images.Primary ? { Primary: imageTag(images.Primary) } : {},
++    BackdropImageTags: [],
++    ParentBackdropItemId: images.Backdrop ? seriesItem.Id : undefined,
++    ParentBackdropImageTags: images.Backdrop
++      ? [imageTag(images.Backdrop)]
++      : undefined,
++    SeriesPrimaryImageTag: images.Primary
++      ? imageTag(images.Primary)
++      : undefined,
++    ParentLogoItemId: meta.logo ? seriesItem.Id : undefined,
++    ParentLogoImageTag: meta.logo ? imageTag(meta.logo) : undefined,
++    PrimaryImageAspectRatio: 0.6666,
++    ProductionYear: seriesItem.ProductionYear,
++    ProviderIds: {},
++    UserData: {
++      ...defaultUserData(id),
++      Played: total > 0 && played >= total,
++      UnplayedItemCount: Math.max(0, total - played),
++      PlayedPercentage: total > 0 ? (played / total) * 100 : 0,
++      ...(inProgress ? {} : {}),
++    },
++  };
++}
++
++export function buildEpisodeItem(
++  ctx: ItemBuildContext,
++  meta: ParsedMeta,
++  seriesItem: JellyfinItem,
++  group: SeasonGroup,
++  video: NonNullable<ParsedMeta['videos']>[number],
++  playstate?: JellyfinPlaystateRow
++): JellyfinItem {
++  const descriptor: JellyfinItemDescriptor = {
++    k: 'episode',
++    t: meta.type,
++    i: meta.id,
++    s: group.season,
++    e: video.episode ?? 0,
++    v: video.id,
++  };
++  const id = encodeJellyfinId(descriptor);
++  const seasonId = encodeJellyfinId({
++    k: 'season',
++    t: meta.type,
++    i: meta.id,
++    s: group.season,
++  });
++  const images: ItemImages = {};
++  if (video.thumbnail) images.Primary = video.thumbnail;
++  if (meta.background) images.Backdrop = meta.background;
++  rememberImages(ctx.uuid, id, images, true);
++
++  const runtimeTicks = parseRuntimeToTicks(meta.runtime);
++  const premiere = toIso(video.released);
++  const unaired = premiere ? new Date(premiere).getTime() > Date.now() : false;
++  const title = video.title ?? video.name ?? `Episode ${video.episode}`;
++
++  return {
++    Id: id,
++    Name: title,
++    SortName: `${String(group.season).padStart(4, '0')}-${String(video.episode ?? 0).padStart(4, '0')}`,
++    ServerId: ctx.serverId,
++    Type: 'Episode',
++    IsFolder: false,
++    MediaType: 'Video',
++    VideoType: 'VideoFile',
++    LocationType: unaired ? 'Virtual' : 'FileSystem',
++    PlayAccess: 'Full',
++    CanDelete: false,
++    CanDownload: !unaired,
++    IndexNumber: video.episode,
++    ParentIndexNumber: group.season,
++    SeriesId: seriesItem.Id,
++    SeriesName: seriesItem.Name,
++    SeasonId: seasonId,
++    SeasonName: group.name,
++    ParentId: seasonId,
++    Overview: video.overview ?? undefined,
++    PremiereDate: premiere,
++    ProductionYear: premiere
++      ? new Date(premiere).getUTCFullYear()
++      : seriesItem.ProductionYear,
++    RunTimeTicks: runtimeTicks,
++    ImageTags: images.Primary ? { Primary: imageTag(images.Primary) } : {},
++    BackdropImageTags: [],
++    ParentBackdropItemId: images.Backdrop ? seriesItem.Id : undefined,
++    ParentBackdropImageTags: images.Backdrop
++      ? [imageTag(images.Backdrop)]
++      : undefined,
++    SeriesPrimaryImageTag: meta.poster ? imageTag(meta.poster) : undefined,
++    ParentLogoItemId: meta.logo ? seriesItem.Id : undefined,
++    ParentLogoImageTag: meta.logo ? imageTag(meta.logo) : undefined,
++    ParentThumbItemId: images.Backdrop ? seriesItem.Id : undefined,
++    ParentThumbImageTag: images.Backdrop
++      ? imageTag(images.Backdrop)
++      : undefined,
++    PrimaryImageAspectRatio: 1.7777,
++    ProviderIds: {},
++    Genres: seriesItem.Genres,
++    CommunityRating: seriesItem.CommunityRating,
++    UserData: playstateToUserData(id, playstate, runtimeTicks),
++    MediaSources: unaired ? undefined : stubMediaSources(id, title),
++    Path: `/${meta.type}/${video.id}`,
++    _aio: { descriptor },
++  };
++}
++
++const ENCODE_TO_CODEC: Record<string, string> = {
++  AV1: 'av1',
++  HEVC: 'hevc',
++  AVC: 'h264',
++  'VC-1': 'vc1',
++  XviD: 'mpeg4',
++  DivX: 'mpeg4',
++  MPEG2: 'mpeg2video',
++};
++const AUDIO_TAG_TO_CODEC: [string, string][] = [
++  ['Atmos', 'truehd'],
++  ['TrueHD', 'truehd'],
++  ['DTS:X', 'dts'],
++  ['DTS-HD MA', 'dts'],
++  ['DTS-HD', 'dts'],
++  ['DTS-ES', 'dts'],
++  ['DTS', 'dts'],
++  ['DD+', 'eac3'],
++  ['DD', 'ac3'],
++  ['OPUS', 'opus'],
++  ['FLAC', 'flac'],
++  ['AAC', 'aac'],
++];
++const RES_TO_SIZE: Record<string, [number, number]> = {
++  '2160p': [3840, 2160],
++  '1440p': [2560, 1440],
++  '1080p': [1920, 1080],
++  '720p': [1280, 720],
++  '576p': [720, 576],
++  '480p': [640, 480],
++  '360p': [480, 360],
++  '240p': [320, 240],
++};
++
++function containerOf(stream: ParsedStream): string {
++  const ext =
++    stream.parsedFile?.container ||
++    stream.parsedFile?.extension ||
++    stream.filename?.split('.').pop() ||
++    (stream.url ? stream.url.split('?')[0].split('.').pop() : undefined);
++  const c = (ext || '').toLowerCase().replace(/^\./, '');
++  if (/^(mkv|mp4|avi|mov|m4v|ts|webm|wmv|flv|m2ts|mpg|mpeg)$/.test(c)) return c;
++  if (stream.type === 'live') return 'ts';
++  return 'mkv';
++}
++
++function channelsOf(tag: string | undefined): number | undefined {
++  if (!tag) return undefined;
++  const m = tag.match(/^(\d+)\.(\d+)$/);
++  if (!m) return undefined;
++  return Number(m[1]) + Number(m[2]);
++}
++
++export function buildMediaStreams(
++  stream: ParsedStream,
++  subtitles: { url: string; lang: string; id: string }[],
++  subtitleUrl: (
++    index: number,
++    sub: { url: string; lang: string; id: string }
++  ) => string
++): JellyfinMediaStream[] {
++  const pf = stream.parsedFile;
++  const streams: JellyfinMediaStream[] = [];
++  let index = 0;
++
++  const res =
++    pf?.resolution && pf.resolution !== 'Unknown' ? pf.resolution : undefined;
++  const size = res ? RES_TO_SIZE[res] : undefined;
++  const encode = pf?.encode && pf.encode !== 'Unknown' ? pf.encode : undefined;
++  const visual = pf?.visualTags ?? [];
++  const hasDV =
++    visual.includes('DV') ||
++    visual.includes('HDR+DV') ||
++    visual.includes('DV Only');
++  const hasHDR = visual.some(
++    (v) => /^HDR/.test(v) || v === 'HLG' || v === 'HDR Only'
++  );
++  const videoRangeType = hasDV
++    ? 'DOVI'
++    : visual.includes('HDR10+')
++      ? 'HDR10Plus'
++      : visual.includes('HDR10')
++        ? 'HDR10'
++        : visual.includes('HLG')
++          ? 'HLG'
++          : hasHDR
++            ? 'HDR10'
++            : 'SDR';
++  const videoRange = hasDV || hasHDR ? 'HDR' : 'SDR';
++  streams.push({
++    Type: 'Video',
++    Index: index++,
++    Codec: encode
++      ? (ENCODE_TO_CODEC[encode] ?? encode.toLowerCase())
++      : undefined,
++    Width: size?.[0],
++    Height: size?.[1],
++    IsDefault: true,
++    IsForced: false,
++    IsExternal: false,
++    IsInterlaced: false,
++    IsTextSubtitleStream: false,
++    SupportsExternalStream: false,
++    VideoRange: videoRange,
++    VideoRangeType: videoRangeType,
++    BitDepth: visual.includes('10bit') || hasDV || hasHDR ? 10 : 8,
++    BitRate: stream.bitrate,
++    DisplayTitle:
++      [res, encode, videoRangeType !== 'SDR' ? videoRangeType : undefined]
++        .filter(Boolean)
++        .join(' ') || 'Video',
++    Language: undefined,
++    AspectRatio: size ? (size[0] / size[1] >= 1.7 ? '16:9' : '4:3') : undefined,
++    Level: undefined,
++    Profile: undefined,
++  });
++
++  const langs = (pf?.languages ?? []).filter((l) => l && l !== 'Unknown');
++  const audioTag = (pf?.audioTags ?? []).find((t) =>
++    AUDIO_TAG_TO_CODEC.some(([k]) => k === t)
++  );
++  const audioCodec = audioTag
++    ? AUDIO_TAG_TO_CODEC.find(([k]) => k === audioTag)?.[1]
++    : undefined;
++  const channels = channelsOf(
++    (pf?.audioChannels ?? []).find((c) => c !== 'Unknown')
++  );
++  const audioLangs = langs.length ? langs : ['Unknown'];
++  audioLangs.forEach((lang, i) => {
++    const code = lang === 'Unknown' ? undefined : languageToCode(lang);
++    streams.push({
++      Type: 'Audio',
++      Index: index++,
++      Codec: audioCodec,
++      Language: code ?? (lang === 'Unknown' ? undefined : lang.toLowerCase()),
++      DisplayTitle:
++        [
++          lang !== 'Unknown' ? lang : undefined,
++          audioTag,
++          pf?.audioChannels?.[0] !== 'Unknown'
++            ? pf?.audioChannels?.[0]
++            : undefined,
++        ]
++          .filter(Boolean)
++          .join(' ') || 'Audio',
++      Channels: channels,
++      ChannelLayout:
++        channels === 6
++          ? '5.1'
++          : channels === 8
++            ? '7.1'
++            : channels === 2
++              ? 'stereo'
++              : undefined,
++      IsDefault: i === 0,
++      IsForced: false,
++      IsExternal: false,
++      IsTextSubtitleStream: false,
++      SupportsExternalStream: false,
++      BitRate: undefined,
++      SampleRate: undefined,
++    });
++  });
++
++  subtitles.forEach((sub, i) => {
++    const ext = (sub.url.split('?')[0].split('.').pop() || 'srt').toLowerCase();
++    const codec = /^(srt|vtt|ass|ssa|sub|sup)$/.test(ext)
++      ? ext === 'vtt'
++        ? 'webvtt'
++        : ext === 'sub'
++          ? 'subrip'
++          : ext
++      : 'srt';
++    const code = languageToCode(sub.lang) ?? sub.lang;
++    streams.push({
++      Type: 'Subtitle',
++      Index: index++,
++      Codec: codec === 'srt' ? 'subrip' : codec,
++      Language: code,
++      DisplayTitle: `${sub.lang} (external)`,
++      Title: sub.lang,
++      IsDefault: false,
++      IsForced: false,
++      IsExternal: true,
++      IsTextSubtitleStream: true,
++      SupportsExternalStream: true,
++      DeliveryMethod: 'External',
++      DeliveryUrl: sub.url,
++      IsExternalUrl: true,
++      Path: sub.url,
++    });
++  });
++
++  return streams;
++}
++
++export interface MediaSourceBuildOptions {
++  baseUrl: string;
++  itemId: string;
++  apiKey: string;
++  encrypt: (plain: string) => string;
++  subtitles: Subtitle[];
++  runtimeTicks?: number;
++}
++
++export function mediaSourceIdFor(stream: ParsedStream): string {
++  return streamIdToMediaSourceId(
++    stream.id || stream.url || JSON.stringify(stream.releaseKey)
++  );
++}
++
++export interface PlayableStreamRecord {
++  msid: string;
++  url: string;
++  headers?: Record<string, string>;
++  responseHeaders?: Record<string, string>;
++  filename?: string;
++  name: string;
++  type: string;
++  size?: number;
++  subtitles?: { id: string; url: string; lang: string }[];
++}
++
++export function streamToPlayable(
++  stream: ParsedStream,
++  name: string
++): PlayableStreamRecord | null {
++  if (!stream.url) return null;
++  if (
++    !stream.proxied &&
++    ((stream.requestHeaders && Object.keys(stream.requestHeaders).length) ||
++      (stream.responseHeaders && Object.keys(stream.responseHeaders).length))
++  ) {
++    return null;
++  }
++  return {
++    msid: mediaSourceIdFor(stream),
++    url: stream.url,
++    headers: stream.requestHeaders,
++    responseHeaders: stream.responseHeaders,
++    filename: stream.filename,
++    name,
++    type: stream.type,
++    size: stream.size,
++    subtitles: stream.subtitles?.map((s) => ({
++      id: s.id,
++      url: s.url,
++      lang: s.lang,
++    })),
++  };
++}
++
++export function buildMediaSource(
++  stream: ParsedStream,
++  formatted: { name: string; description: string },
++  opts: MediaSourceBuildOptions
++): JellyfinMediaSource | null {
++  if (!stream.url) return null;
++  if (
++    !stream.proxied &&
++    ((stream.requestHeaders && Object.keys(stream.requestHeaders).length) ||
++      (stream.responseHeaders && Object.keys(stream.responseHeaders).length))
++  ) {
++    return null;
++  }
++  const msid = mediaSourceIdFor(stream);
++  const container = containerOf(stream);
++  const path = stream.url;
++
++  const subs: { url: string; lang: string; id: string }[] = [
++    ...(stream.subtitles ?? []).map((s) => ({
++      url: s.url,
++      lang: s.lang,
++      id: s.id,
++    })),
++    ...opts.subtitles.map((s) => ({ url: s.url, lang: s.lang, id: s.id })),
++  ];
++  const mediaStreams = buildMediaStreams(
++    stream,
++    subs,
++    (i, sub) =>
++      `/Videos/${opts.itemId}/${msid}/Subtitles/${i}/0/Stream.${(sub.url.split('?')[0].split('.').pop() || 'srt').toLowerCase().replace(/[^a-z0-9]/g, '') || 'srt'}?api_key=${encodeURIComponent(opts.apiKey)}&u=${encodeURIComponent(opts.encrypt(sub.url))}`
++  );
++  const name = [formatted.name, formatted.description]
++    .filter(Boolean)
++    .join('\n');
++  const isLive = stream.type === 'live';
++  const subtitleIndex = mediaStreams.findIndex((s) => s.Type === 'Subtitle');
++
++  return {
++    Protocol: 'Http',
++    Id: msid,
++    Path: path,
++    DirectStreamUrl: path,
++    EncoderProtocol: undefined,
++    Type: 'Default',
++    Container: container,
++    Size: stream.size,
++    Name: name,
++    IsRemote: true,
++    ETag: msid,
++    RunTimeTicks: isLive
++      ? undefined
++      : stream.duration
++        ? stream.duration * TICKS_PER_MS
++        : opts.runtimeTicks,
++    ReadAtNativeFramerate: false,
++    IgnoreDts: false,
++    IgnoreIndex: false,
++    GenPtsInput: false,
++    SupportsTranscoding: false,
++    SupportsDirectStream: true,
++    SupportsDirectPlay: true,
++    IsInfiniteStream: isLive,
++    RequiresOpening: false,
++    RequiresClosing: false,
++    RequiresLooping: false,
++    SupportsProbing: false,
++    VideoType: 'VideoFile',
++    MediaStreams: mediaStreams,
++    MediaAttachments: [],
++    Formats: [],
++    Bitrate: stream.bitrate,
++    RequiredHttpHeaders: {},
++    DefaultAudioStreamIndex: mediaStreams.findIndex((s) => s.Type === 'Audio'),
++    DefaultSubtitleStreamIndex: -1,
++    HasSegments: false,
++  };
++}
+diff --git a/packages/core/src/jellyfin/ids-codec.ts b/packages/core/src/jellyfin/ids-codec.ts
+new file mode 100644
+index 00000000..bc6f859b
+--- /dev/null
++++ b/packages/core/src/jellyfin/ids-codec.ts
+@@ -0,0 +1,201 @@
++import { createHash } from 'crypto';
++import type { JellyfinItemDescriptor } from '../db/repositories/jellyfin.js';
++import { IdParser } from '../utils/id-parser.js';
++
++const PACKED = 0xa1;
++const HASHED = 0xb2;
++
++const KIND_CODES: Record<string, number> = {
++  movie: 1,
++  series: 2,
++  season: 3,
++  episode: 4,
++};
++const KIND_BY_CODE = Object.fromEntries(
++  Object.entries(KIND_CODES).map(([k, v]) => [v, k])
++) as Record<number, 'movie' | 'series' | 'season' | 'episode'>;
++
++const ID_TYPE_CODES: Record<string, number> = {
++  imdbId: 1,
++  themoviedbId: 2,
++  thetvdbId: 3,
++  kitsuId: 4,
++  malId: 5,
++  anilistId: 6,
++  anidbId: 7,
++  simklId: 8,
++};
++const ID_TYPE_BY_CODE = Object.fromEntries(
++  Object.entries(ID_TYPE_CODES).map(([k, v]) => [v, k])
++);
++const ID_PREFIX_BY_TYPE: Record<string, string> = {
++  imdbId: 'tt',
++  themoviedbId: 'tmdb:',
++  thetvdbId: 'tvdb:',
++  kitsuId: 'kitsu:',
++  malId: 'mal:',
++  anilistId: 'anilist:',
++  anidbId: 'anidb:',
++  simklId: 'simkl:',
++};
++
++const MEDIA_TYPE_CODES: Record<string, number> = {
++  movie: 1,
++  series: 2,
++  anime: 3,
++  tv: 4,
++  other: 5,
++  channel: 6,
++};
++const MEDIA_TYPE_BY_CODE = Object.fromEntries(
++  Object.entries(MEDIA_TYPE_CODES).map(([k, v]) => [v, k])
++);
++
++const NONE16 = 0xffff;
++const MAX48 = 2 ** 48 - 1;
++
++function rebuildBaseId(idType: string, numeric: number): string {
++  const prefix = ID_PREFIX_BY_TYPE[idType];
++  if (idType === 'imdbId') return `tt${String(numeric).padStart(7, '0')}`;
++  return `${prefix}${numeric}`;
++}
++
++function tryPack(d: JellyfinItemDescriptor): string | null {
++  if (
++    d.k !== 'movie' &&
++    d.k !== 'series' &&
++    d.k !== 'season' &&
++    d.k !== 'episode'
++  )
++    return null;
++  const mediaCode = MEDIA_TYPE_CODES[d.t];
++  if (!mediaCode) return null;
++  const parsed = IdParser.parse(d.i, d.t);
++  if (!parsed || parsed.season || parsed.episode) return null;
++  const idTypeCode = ID_TYPE_CODES[parsed.type];
++  if (!idTypeCode) return null;
++  const rawValue = String(parsed.value);
++  const numeric = Number(
++    parsed.type === 'imdbId' ? rawValue.replace(/^tt/, '') : rawValue
++  );
++  if (!Number.isInteger(numeric) || numeric < 0 || numeric > MAX48) return null;
++  if (rebuildBaseId(parsed.type, numeric) !== d.i) return null;
++
++  let season = NONE16;
++  let episode = NONE16;
++  if (d.k === 'season') {
++    if (!Number.isInteger(d.s) || d.s < 0 || d.s >= NONE16) return null;
++    season = d.s;
++  } else if (d.k === 'episode') {
++    if (!Number.isInteger(d.s) || d.s < 0 || d.s >= NONE16) return null;
++    if (!Number.isInteger(d.e) || d.e < 0 || d.e >= NONE16) return null;
++    if (parsed.generator(parsed.value, String(d.s), String(d.e)) !== d.v)
++      return null;
++    season = d.s;
++    episode = d.e;
++  }
++
++  const buf = Buffer.alloc(16);
++  buf[0] = PACKED;
++  buf[1] = (KIND_CODES[d.k] << 4) | idTypeCode;
++  buf[2] = mediaCode;
++  buf.writeUIntBE(numeric, 3, 6);
++  buf.writeUInt16BE(season, 9);
++  buf.writeUInt16BE(episode, 11);
++  return buf.toString('hex');
++}
++
++function tryUnpack(hex: string): JellyfinItemDescriptor | null {
++  const buf = Buffer.from(hex, 'hex');
++  if (buf.length !== 16 || buf[0] !== PACKED) return null;
++  const kind = KIND_BY_CODE[buf[1] >> 4];
++  const idType = ID_TYPE_BY_CODE[buf[1] & 0x0f];
++  const mediaType = MEDIA_TYPE_BY_CODE[buf[2]];
++  if (!kind || !idType || !mediaType) return null;
++  const numeric = buf.readUIntBE(3, 6);
++  const season = buf.readUInt16BE(9);
++  const episode = buf.readUInt16BE(11);
++  const baseId = rebuildBaseId(idType, numeric);
++  switch (kind) {
++    case 'movie':
++    case 'series':
++      return { k: kind, t: mediaType, i: baseId };
++    case 'season':
++      return { k: 'season', t: mediaType, i: baseId, s: season };
++    case 'episode': {
++      const parsed = IdParser.parse(baseId, mediaType);
++      if (!parsed) return null;
++      return {
++        k: 'episode',
++        t: mediaType,
++        i: baseId,
++        s: season,
++        e: episode,
++        v: parsed.generator(parsed.value, String(season), String(episode)),
++      };
++    }
++  }
++}
++
++export function normaliseJellyfinId(id: string): string {
++  return id.replace(/-/g, '').toLowerCase();
++}
++
++export function dashedGuid(hex32: string): string {
++  return `${hex32.slice(0, 8)}-${hex32.slice(8, 12)}-${hex32.slice(12, 16)}-${hex32.slice(16, 20)}-${hex32.slice(20)}`;
++}
++
++export function canonicalDescriptor(d: JellyfinItemDescriptor): string {
++  switch (d.k) {
++    case 'view':
++      return `view|${d.t}|${d.c}`;
++    case 'genre':
++      return `genre|${d.t}|${d.c}|${d.g}`;
++    case 'movie':
++    case 'series':
++      return `${d.k}|${d.t}|${d.i}`;
++    case 'season':
++      return `season|${d.t}|${d.i}|${d.s}`;
++    case 'episode':
++      return `episode|${d.t}|${d.i}|${d.s}|${d.e}|${d.v}`;
++    case 'person':
++    case 'studio':
++      return `${d.k}|${d.n}`;
++  }
++}
++
++export function packJellyfinId(d: JellyfinItemDescriptor): string | null {
++  return tryPack(d);
++}
++
++export function unpackJellyfinId(raw: string): JellyfinItemDescriptor | null {
++  const id = normaliseJellyfinId(raw);
++  if (!/^[0-9a-f]{32}$/.test(id)) return null;
++  return tryUnpack(id);
++}
++
++export function hashJellyfinId(d: JellyfinItemDescriptor): string {
++  const hash = createHash('md5').update(canonicalDescriptor(d)).digest();
++  hash[0] = HASHED;
++  return hash.toString('hex');
++}
++
++export function isHashedJellyfinId(id: string): boolean {
++  return normaliseJellyfinId(id).slice(0, 2) === HASHED.toString(16);
++}
++
++export function uuidToJellyfinUserId(uuid: string): string {
++  return normaliseJellyfinId(uuid);
++}
++
++export function jellyfinUserIdToUuid(id: string): string {
++  return dashedGuid(normaliseJellyfinId(id));
++}
++
++export function streamIdToMediaSourceId(streamId: string): string {
++  return createHash('md5').update(streamId).digest('hex');
++}
++
++export function imageTag(url: string): string {
++  return createHash('md5').update(url).digest('hex').slice(0, 16);
++}
+diff --git a/packages/core/src/jellyfin/ids.test.ts b/packages/core/src/jellyfin/ids.test.ts
+new file mode 100644
+index 00000000..c61b23ea
+--- /dev/null
++++ b/packages/core/src/jellyfin/ids.test.ts
+@@ -0,0 +1,140 @@
++import { describe, it } from 'node:test';
++import assert from 'node:assert/strict';
++import type { JellyfinItemDescriptor } from '../db/repositories/jellyfin.js';
++import {
++  canonicalDescriptor,
++  dashedGuid,
++  hashJellyfinId,
++  normaliseJellyfinId,
++  packJellyfinId,
++  unpackJellyfinId,
++  uuidToJellyfinUserId,
++} from './ids-codec.js';
++
++const encodeJellyfinId = (d: JellyfinItemDescriptor) =>
++  packJellyfinId(d) ?? hashJellyfinId(d);
++const decodeJellyfinId = async (raw: string) => unpackJellyfinId(raw);
++
++const PACKABLE: JellyfinItemDescriptor[] = [
++  { k: 'movie', t: 'movie', i: 'tt0111161' },
++  { k: 'series', t: 'series', i: 'tt9288030' },
++  { k: 'series', t: 'anime', i: 'kitsu:1376' },
++  { k: 'movie', t: 'movie', i: 'tmdb:550' },
++  { k: 'series', t: 'series', i: 'tvdb:81189' },
++  { k: 'season', t: 'series', i: 'tt9288030', s: 2 },
++  { k: 'season', t: 'series', i: 'tt9288030', s: 0 },
++  {
++    k: 'episode',
++    t: 'series',
++    i: 'tt9288030',
++    s: 1,
++    e: 3,
++    v: 'tt9288030:1:3',
++  },
++  { k: 'episode', t: 'anime', i: 'mal:5114', s: 1, e: 13, v: 'mal:5114:13' },
++];
++
++describe('jellyfin id codec', () => {
++  it('packs standard ids into valid 32-hex GUIDs and round-trips them', async () => {
++    for (const d of PACKABLE) {
++      const id = encodeJellyfinId(d);
++      assert.match(id, /^a1[0-9a-f]{30}$/);
++      const decoded = await decodeJellyfinId(id);
++      assert.deepEqual(decoded, d);
++      const decoded2 = await decodeJellyfinId(dashedGuid(id).toUpperCase());
++      assert.deepEqual(decoded2, d);
++    }
++  });
++
++  it('is deterministic', () => {
++    const d: JellyfinItemDescriptor = {
++      k: 'movie',
++      t: 'movie',
++      i: 'tt0111161',
++    };
++    assert.deepEqual(encodeJellyfinId(d), encodeJellyfinId(d));
++  });
++
++  it('gives distinct ids to distinct descriptors', () => {
++    const ids = new Set(PACKABLE.map(encodeJellyfinId));
++    assert.equal(ids.size, PACKABLE.length);
++  });
++
++  it('falls back to hashed ids for non-numeric or exotic ids', () => {
++    const exotic: JellyfinItemDescriptor[] = [
++      {
++        k: 'movie',
++        t: 'movie',
++        i: 'aiostreams::library.realdebrid.torrent.abc',
++      },
++      { k: 'view', t: 'movie', c: 'catalog.popular' },
++      { k: 'genre', t: 'movie', c: 'catalog.popular', g: 'Action' },
++      { k: 'person', n: 'Alan Ritchson' },
++      {
++        k: 'episode',
++        t: 'series',
++        i: 'tt9288030',
++        s: 1,
++        e: 3,
++        v: 'weird-video-id',
++      },
++    ];
++    for (const d of exotic) {
++      const id = encodeJellyfinId(d);
++      assert.match(id, /^b2[0-9a-f]{30}$/);
++    }
++  });
++
++  it('keeps imdb leading zeros intact', async () => {
++    const d: JellyfinItemDescriptor = {
++      k: 'movie',
++      t: 'movie',
++      i: 'tt0000001',
++    };
++    const id = encodeJellyfinId(d);
++    assert.match(id, /^a1/);
++    assert.deepEqual(await decodeJellyfinId(id), d);
++  });
++
++  it('hashes imdb ids longer than 7 digits with leading zeros ambiguity safely', async () => {
++    const d: JellyfinItemDescriptor = {
++      k: 'movie',
++      t: 'movie',
++      i: 'tt37287335',
++    };
++    const id = encodeJellyfinId(d);
++    if (id.startsWith('a1')) {
++      assert.deepEqual(await decodeJellyfinId(id), d);
++    } else {
++      assert.match(id, /^b2/);
++    }
++  });
++
++  it('normalises and formats guids', () => {
++    const hex = 'a1210200000000d17affffffff000000';
++    assert.equal(normaliseJellyfinId(dashedGuid(hex)), hex);
++    assert.match(
++      dashedGuid(hex),
++      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
++    );
++  });
++
++  it('maps config uuids to jellyfin user ids', () => {
++    assert.equal(
++      uuidToJellyfinUserId('01234567-89ab-cdef-0123-456789abcdef'),
++      '0123456789abcdef0123456789abcdef'
++    );
++  });
++
++  it('rejects garbage', async () => {
++    assert.equal(await decodeJellyfinId('not-a-guid'), null);
++    assert.equal(await decodeJellyfinId('a1'.padEnd(32, 'z')), null);
++  });
++
++  it('canonical descriptors are unique per field set', () => {
++    assert.notEqual(
++      canonicalDescriptor({ k: 'season', t: 'series', i: 'x', s: 1 }),
++      canonicalDescriptor({ k: 'season', t: 'series', i: 'x', s: 2 })
++    );
++  });
++});
+diff --git a/packages/core/src/jellyfin/ids.ts b/packages/core/src/jellyfin/ids.ts
+new file mode 100644
+index 00000000..65b71f82
+--- /dev/null
++++ b/packages/core/src/jellyfin/ids.ts
+@@ -0,0 +1,80 @@
++import {
++  JellyfinRepository,
++  type JellyfinItemDescriptor,
++} from '../db/index.js';
++import { Cache } from '../utils/cache.js';
++import { createLogger } from '../logging/logger.js';
++import {
++  canonicalDescriptor,
++  hashJellyfinId,
++  isHashedJellyfinId,
++  normaliseJellyfinId,
++  packJellyfinId,
++  unpackJellyfinId,
++} from './ids-codec.js';
++
++export * from './ids-codec.js';
++
++const logger = createLogger('jellyfin');
++
++const idCache = Cache.getInstance<string, JellyfinItemDescriptor>(
++  'jellyfin-ids',
++  100_000
++);
++const ID_CACHE_TTL = 30 * 24 * 3600;
++
++const persisted = new Set<string>();
++const PERSISTED_MAX = 50_000;
++let pending: { id: string; payload: JellyfinItemDescriptor }[] = [];
++let flushTimer: NodeJS.Timeout | null = null;
++
++function scheduleFlush() {
++  if (flushTimer) return;
++  flushTimer = setTimeout(async () => {
++    flushTimer = null;
++    const batch = pending;
++    pending = [];
++    try {
++      await JellyfinRepository.rememberItems(batch);
++    } catch (e) {
++      logger.warn(
++        `Failed to persist ${batch.length} jellyfin id mappings: ${e instanceof Error ? e.message : e}`
++      );
++      for (const b of batch) persisted.delete(b.id);
++    }
++  }, 250);
++}
++
++export function encodeJellyfinId(d: JellyfinItemDescriptor): string {
++  const packed = packJellyfinId(d);
++  if (packed) return packed;
++  const id = hashJellyfinId(d);
++  if (!persisted.has(id)) {
++    if (persisted.size >= PERSISTED_MAX) persisted.clear();
++    persisted.add(id);
++    pending.push({ id, payload: d });
++    scheduleFlush();
++    void idCache.set(id, d, ID_CACHE_TTL).catch(() => undefined);
++  }
++  return id;
++}
++
++export async function decodeJellyfinId(
++  raw: string
++): Promise<JellyfinItemDescriptor | null> {
++  const id = normaliseJellyfinId(raw);
++  if (!/^[0-9a-f]{32}$/.test(id)) return null;
++  const unpacked = unpackJellyfinId(id);
++  if (unpacked) return unpacked;
++  if (!isHashedJellyfinId(id)) return null;
++  const cached = await idCache.get(id).catch(() => undefined);
++  if (cached) return cached;
++  const stored = await JellyfinRepository.lookupItem(id);
++  if (stored) {
++    void idCache.set(id, stored, ID_CACHE_TTL).catch(() => undefined);
++    return stored;
++  }
++  return null;
++}
++
++export { canonicalDescriptor };
+diff --git a/packages/core/src/jellyfin/images.test.ts b/packages/core/src/jellyfin/images.test.ts
+new file mode 100644
+index 00000000..6e4b9b45
+--- /dev/null
++++ b/packages/core/src/jellyfin/images.test.ts
+@@ -0,0 +1,67 @@
++import { describe, it } from 'node:test';
++import assert from 'node:assert/strict';
++import { Cache } from '../utils/index.js';
++import { rememberImages, recallImages } from './images.js';
++
++const settle = () => new Promise((r) => setTimeout(r, 0));
++
++describe('jellyfin image memory', () => {
++  it('does not let a catalog preview claim to be the whole answer', async () => {
++    rememberImages('u1', 'preview-item', { Primary: 'poster.jpg' });
++    await settle();
++
++    const entry = await recallImages('u1', 'preview-item');
++    assert.equal(entry?.images.Primary, 'poster.jpg');
++    assert.equal(entry?.complete, false);
++  });
++
++  it('lets a full build claim completeness', async () => {
++    rememberImages(
++      'u1',
++      'full-item',
++      { Primary: 'p', Backdrop: 'b', Logo: 'l' },
++      true
++    );
++    await settle();
++
++    const entry = await recallImages('u1', 'full-item');
++    assert.equal(entry?.complete, true);
++    assert.equal(entry?.images.Logo, 'l');
++  });
++
++  it('remembers a complete-but-empty result as a definitive "no artwork"', async () => {
++    rememberImages('u1', 'artless', {}, true);
++    await settle();
++
++    const entry = await recallImages('u1', 'artless');
++    assert.ok(entry);
++    assert.equal(entry.complete, true);
++    assert.deepEqual(entry.images, {});
++  });
++
++  it('does not write an incomplete-and-empty result, which says nothing', async () => {
++    rememberImages('u1', 'unknown', {});
++    await settle();
++
++    assert.equal(await recallImages('u1', 'unknown'), undefined);
++  });
++
++  it('scopes remembered URLs per user', async () => {
++    rememberImages('u1', 'shared-id', {
++      Primary: 'https://addon/p.jpg?key=SECRET',
++    });
++    await settle();
++
++    assert.equal(await recallImages('u2', 'shared-id'), undefined);
++  });
++
++  it('reads entries written before completeness existed as incomplete', async () => {
++    const raw = Cache.getInstance<string, unknown>('jellyfin-images', 50_000);
++    await raw.set('u1|legacy', { Primary: 'old.jpg' }, 3600);
++    await settle();
++
++    const entry = await recallImages('u1', 'legacy');
++    assert.equal(entry?.images.Primary, 'old.jpg');
++    assert.equal(entry?.complete, false);
++  });
++});
+diff --git a/packages/core/src/jellyfin/images.ts b/packages/core/src/jellyfin/images.ts
+new file mode 100644
+index 00000000..de2d0bd7
+--- /dev/null
++++ b/packages/core/src/jellyfin/images.ts
+@@ -0,0 +1,52 @@
++import { Cache } from '../utils/cache.js';
++
++export interface ItemImages {
++  Primary?: string;
++  Backdrop?: string;
++  Logo?: string;
++  Thumb?: string;
++}
++
++export interface RememberedImages {
++  images: ItemImages;
++  complete: boolean;
++}
++
++const imageCache = Cache.getInstance<string, RememberedImages>(
++  'jellyfin-images',
++  50_000
++);
++const TTL = 7 * 24 * 3600;
++const EMPTY_TTL = 10 * 60;
++
++function key(uuid: string, itemId: string): string {
++  return `${uuid}|${itemId}`;
++}
++
++function isEmpty(images: ItemImages): boolean {
++  return !images.Primary && !images.Backdrop && !images.Logo && !images.Thumb;
++}
++
++export function rememberImages(
++  uuid: string,
++  itemId: string,
++  images: ItemImages,
++  complete = false
++): void {
++  const empty = isEmpty(images);
++  if (empty && !complete) return;
++  void imageCache
++    .set(key(uuid, itemId), { images, complete }, empty ? EMPTY_TTL : TTL)
++    .catch(() => undefined);
++}
++
++export async function recallImages(
++  uuid: string,
++  itemId: string
++): Promise<RememberedImages | undefined> {
++  const entry = await imageCache.get(key(uuid, itemId)).catch(() => undefined);
++  if (!entry) return undefined;
++  if (typeof entry.complete !== 'boolean' || !entry.images)
++    return { images: entry as unknown as ItemImages, complete: false };
++  return entry;
++}
+diff --git a/packages/core/src/jellyfin/index.ts b/packages/core/src/jellyfin/index.ts
+new file mode 100644
+index 00000000..a6942fe4
+--- /dev/null
++++ b/packages/core/src/jellyfin/index.ts
+@@ -0,0 +1,4 @@
++export * from './ids.js';
++export * from './dto.js';
++export * from './images.js';
++export * from './service.js';
+diff --git a/packages/core/src/jellyfin/service.ts b/packages/core/src/jellyfin/service.ts
+new file mode 100644
+index 00000000..6c2f634c
+--- /dev/null
++++ b/packages/core/src/jellyfin/service.ts
+@@ -0,0 +1,345 @@
++import { AIOStreams } from '../main/index.js';
++import type {
++  Manifest,
++  MetaPreview,
++  ParsedMeta,
++  ParsedStream,
++  Subtitle,
++  UserData,
++} from '../db/schemas.js';
++import { createFormatter } from '../formatters/index.js';
++import { createLogger } from '../logging/logger.js';
++import { config as appConfig } from '../config/index.js';
++import {
++  buildMediaSource,
++  streamToPlayable,
++  type JellyfinMediaSource,
++  type MediaSourceBuildOptions,
++  type PlayableStreamRecord,
++} from './dto.js';
++
++const logger = createLogger('jellyfin');
++
++type Catalog = NonNullable<Manifest['catalogs']>[number];
++
++const STREMIO_PAGE_GUESS = 100;
++
++export interface CatalogPageOptions {
++  startIndex: number;
++  limit: number;
++  search?: string;
++  genre?: string;
++}
++
++export interface CatalogPageResult {
++  items: MetaPreview[];
++  hasMore: boolean;
++  capped: boolean;
++}
++
++export interface ResolvedStreams {
++  streams: ParsedStream[];
++  formatted: { name: string; description: string }[];
++  subtitles: Subtitle[];
++  errors: { title?: string; description?: string }[];
++}
++
++export class JellyfinService {
++  private engine: AIOStreams | null = null;
++  private initPromise: Promise<AIOStreams> | null = null;
++  private readonly metaMemo = new Map<string, Promise<ParsedMeta | null>>();
++  private readonly catalogMemo = new Map<string, Promise<MetaPreview[]>>();
++  private readonly subtitleMemo = new Map<string, Promise<Subtitle[]>>();
++  private readonly streamsMemo = new Map<string, Promise<ResolvedStreams>>();
++
++  constructor(readonly userData: UserData) {}
++
++  async getEngine(): Promise<AIOStreams> {
++    if (this.engine) return this.engine;
++    if (!this.initPromise) {
++      this.initPromise = new AIOStreams(this.userData, {
++        skipFailedAddons: true,
++      })
++        .initialise()
++        .then((e) => {
++          this.engine = e;
++          return e;
++        });
++    }
++    return this.initPromise;
++  }
++
++  async getCatalogs(): Promise<Catalog[]> {
++    const engine = await this.getEngine();
++    return (engine.getCatalogs() ?? []) as Catalog[];
++  }
++
++  async findCatalog(type: string, id: string): Promise<Catalog | undefined> {
++    const catalogs = await this.getCatalogs();
++    return catalogs.find((c) => c.type === type && c.id === id);
++  }
++
++  private fetchCatalog(
++    type: string,
++    id: string,
++    extras?: string
++  ): Promise<MetaPreview[]> {
++    const k = `${type}|${id}|${extras ?? ''}`;
++    let memo = this.catalogMemo.get(k);
++    if (!memo) {
++      memo = (async () => {
++        const engine = await this.getEngine();
++        const res = await engine.getCatalog(type, id, extras);
++        if (res.errors?.length) {
++          logger.debug(
++            { type, id, extras, errors: res.errors.length },
++            'catalog returned with errors'
++          );
++        }
++        return (res.data ?? []).filter((m) => m && m.id);
++      })();
++      this.catalogMemo.set(k, memo);
++    }
++    return memo;
++  }
++
++  async getCatalogPage(
++    catalog: Catalog,
++    opts: CatalogPageOptions
++  ): Promise<CatalogPageResult> {
++    const supports = (name: string) =>
++      (catalog.extra ?? []).some((e) => e.name === name);
++    const cap = appConfig.api.jellyfinMaxCatalogItems || Infinity;
++    const extrasBase: string[] = [];
++    if (opts.search) {
++      if (!supports('search'))
++        return { items: [], hasMore: false, capped: false };
++      extrasBase.push(`search=${opts.search}`);
++    }
++    if (opts.genre) {
++      if (!supports('genre'))
++        return { items: [], hasMore: false, capped: false };
++      extrasBase.push(`genre=${opts.genre}`);
++    }
++    const canSkip = supports('skip');
++    const wantEnd = Math.min(opts.startIndex + opts.limit, cap);
++    if (opts.startIndex >= wantEnd) {
++      return { items: [], hasMore: false, capped: opts.startIndex >= cap };
++    }
++
++    const out: MetaPreview[] = [];
++    let offset = 0;
++    let skip = 0;
++    let hasMore = true;
++    let guard = 0;
++    while (offset < wantEnd && hasMore && guard++ < 50) {
++      const extras = [...extrasBase];
++      if (skip > 0) {
++        if (!canSkip) break;
++        extras.push(`skip=${skip}`);
++      }
++      const page = await this.fetchCatalog(
++        catalog.type,
++        catalog.id,
++        extras.length ? extras.join('&') : undefined
++      );
++      if (page.length === 0) {
++        hasMore = false;
++        break;
++      }
++      for (const item of page) {
++        if (offset >= opts.startIndex && offset < wantEnd) out.push(item);
++        offset++;
++      }
++      skip += page.length;
++      if (page.length < Math.min(STREMIO_PAGE_GUESS, 20)) hasMore = false;
++      if (!canSkip) hasMore = false;
++    }
++    const capped = wantEnd < opts.startIndex + opts.limit && offset >= cap;
++    return {
++      items: out,
++      hasMore: hasMore && offset >= wantEnd && wantEnd < cap,
++      capped,
++    };
++  }
++
++  async getCatalogGenres(catalog: Catalog): Promise<string[]> {
++    const extra = (catalog.extra ?? []).find((e) => e.name === 'genre');
++    return (extra?.options ?? []).filter(
++      (o): o is string => typeof o === 'string' && o.length > 0
++    );
++  }
++
++  async search(
++    term: string,
++    types?: string[],
++    limit = 50
++  ): Promise<MetaPreview[]> {
++    const catalogs = (await this.getCatalogs()).filter(
++      (c) =>
++        (c.extra ?? []).some((e) => e.name === 'search') &&
++        (!types || types.includes(c.type))
++    );
++    const results = await Promise.allSettled(
++      catalogs.map((c) =>
++        this.getCatalogPage(c, { startIndex: 0, limit, search: term })
++      )
++    );
++    const seen = new Set<string>();
++    const out: MetaPreview[] = [];
++    for (const r of results) {
++      if (r.status !== 'fulfilled') continue;
++      for (const item of r.value.items) {
++        const k = `${item.type}|${item.id}`;
++        if (seen.has(k)) continue;
++        seen.add(k);
++        out.push(item);
++      }
++    }
++    return out.slice(0, limit);
++  }
++
++  getMeta(type: string, id: string): Promise<ParsedMeta | null> {
++    const k = `${type}|${id}`;
++    let memo = this.metaMemo.get(k);
++    if (!memo) {
++      memo = (async () => {
++        const engine = await this.getEngine();
++        const res = await engine.getMeta(type, id);
++        return res.data ?? null;
++      })();
++      this.metaMemo.set(k, memo);
++    }
++    return memo;
++  }
++
++  async getMetaLoose(type: string, id: string): Promise<ParsedMeta | null> {
++    const order =
++      type === 'anime'
++        ? [type, 'series']
++        : type === 'series'
++          ? [type, 'anime']
++          : [type];
++    for (const t of order) {
++      try {
++        const meta = await this.getMeta(t, id);
++        if (meta) return meta;
++      } catch (e) {
++        logger.debug(
++          `meta ${t}/${id} failed: ${e instanceof Error ? e.message : e}`
++        );
++      }
++    }
++    return null;
++  }
++
++  async resolveVideoId(type: string, id: string): Promise<string> {
++    const meta = await this.getMetaLoose(type, id).catch(() => null);
++    const hinted = meta?.behaviorHints?.defaultVideoId;
++    if (typeof hinted === 'string' && hinted) return hinted;
++    if (typeof meta?.id === 'string' && meta.id) return meta.id;
++    return id;
++  }
++
++  getSubtitles(type: string, videoId: string): Promise<Subtitle[]> {
++    const k = `${type}|${videoId}`;
++    let memo = this.subtitleMemo.get(k);
++    if (!memo) {
++      memo = (async () => {
++        try {
++          const engine = await this.getEngine();
++          const res = await engine.getSubtitles(type, videoId);
++          return res.data ?? [];
++        } catch (e) {
++          logger.debug(
++            `subtitles ${type}/${videoId} failed: ${e instanceof Error ? e.message : e}`
++          );
++          return [];
++        }
++      })();
++      this.subtitleMemo.set(k, memo);
++    }
++    return memo;
++  }
++
++  resolveStreams(
++    type: string,
++    videoId: string,
++    withSubtitles = true
++  ): Promise<ResolvedStreams> {
++    const k = `${type}|${videoId}|${withSubtitles ? 1 : 0}`;
++    let memo = this.streamsMemo.get(k);
++    if (!memo) {
++      memo = (async () => {
++        const engine = await this.getEngine();
++        const [response, subtitles] = await Promise.all([
++          engine.getStreams(videoId, type),
++          withSubtitles
++            ? this.getSubtitles(type, videoId)
++            : Promise.resolve([] as Subtitle[]),
++        ]);
++        const streams = response.data.streams.filter((s) => !!s.url);
++        const ctx = engine.getStreamContext();
++        const formatter = ctx
++          ? createFormatter(ctx.toFormatterContext(streams))
++          : null;
++        const formatted = await Promise.all(
++          streams.map(async (s) => {
++            if (s.addon.formatPassthrough || !formatter) {
++              return {
++                name: s.originalName || s.addon.name,
++                description: s.originalDescription || '',
++              };
++            }
++            try {
++              return await formatter.format(s);
++            } catch {
++              return {
++                name: s.originalName || s.addon.name,
++                description: s.originalDescription || '',
++              };
++            }
++          })
++        );
++        return {
++          streams,
++          formatted,
++          subtitles,
++          errors: response.errors ?? [],
++        };
++      })();
++      this.streamsMemo.set(k, memo);
++    }
++    return memo;
++  }
++
++  async resolvePlayable(
++    type: string,
++    videoId: string
++  ): Promise<PlayableStreamRecord[]> {
++    const resolved = await this.resolveStreams(type, videoId, false);
++    return resolved.streams
++      .map((s, i) => streamToPlayable(s, resolved.formatted[i].name))
++      .filter((p): p is PlayableStreamRecord => p !== null);
++  }
++
++  async buildMediaSources(
++    type: string,
++    videoId: string,
++    opts: Omit<MediaSourceBuildOptions, 'subtitles'>
++  ): Promise<{
++    sources: JellyfinMediaSource[];
++    errors: ResolvedStreams['errors'];
++  }> {
++    const resolved = await this.resolveStreams(type, videoId);
++    const sources = resolved.streams
++      .map((s, i) =>
++        buildMediaSource(s, resolved.formatted[i], {
++          ...opts,
++          subtitles: resolved.subtitles,
++        })
++      )
++      .filter((m): m is JellyfinMediaSource => m !== null);
++    return { sources, errors: resolved.errors };
++  }
++}
+diff --git a/packages/server/src/routes/jellyfin/context.ts b/packages/server/src/routes/jellyfin/context.ts
+new file mode 100644
+index 00000000..f2dc3e6b
+--- /dev/null
++++ b/packages/server/src/routes/jellyfin/context.ts
+@@ -0,0 +1,492 @@
++import type { Request, Response, NextFunction, RequestHandler } from 'express';
++import {
++  APIError,
++  config as appConfig,
++  constants,
++  createLogger,
++  decryptString,
++  encryptString,
++  isConfigUuid,
++  isEncrypted,
++  resolveConfigAlias,
++  UserRepository,
++  validateConfig,
++  JellyfinRepository,
++  JellyfinService,
++  uuidToJellyfinUserId,
++  type UserData,
++  type ItemBuildContext,
++} from '@aiostreams/core';
++import { syncUserDataUrls } from '../../utils/syncUserData.js';
++
++const logger = createLogger('jellyfin');
++
++export const JELLYFIN_SERVER_VERSION = '10.10.7';
++export const JELLYFIN_PRODUCT_NAME = 'Jellyfin Server';
++
++export interface JellyfinRequestContext {
++  uuid: string;
++  encryptedPassword: string;
++  userData: UserData;
++  userId: string;
++  serverId: string;
++  service: JellyfinService;
++  build: ItemBuildContext;
++  baseUrl: string;
++  apiKey: string;
++  client: { name: string; device: string; deviceId: string; version: string };
++  preAuthenticated: boolean;
++}
++
++export function param(req: Request, name: string): string {
++  const v = (req.params as Record<string, string | string[] | undefined>)[name];
++  return Array.isArray(v) ? (v[0] ?? '') : (v ?? '');
++}
++
++export interface TokenPayload {
++  u: string;
++  p: string;
++  d?: string;
++}
++
++export function mintToken(payload: TokenPayload): string {
++  const res = encryptString(JSON.stringify(payload));
++  if (!res.success || !res.data) throw new Error('Failed to create token');
++  return res.data;
++}
++
++export function readToken(token: string): TokenPayload | null {
++  const res = decryptString(token);
++  if (!res.success || !res.data) return null;
++  try {
++    const parsed = JSON.parse(res.data);
++    if (parsed && typeof parsed.u === 'string' && typeof parsed.p === 'string')
++      return parsed;
++  } catch {}
++  return null;
++}
++
++export function parseMediaBrowserHeader(
++  value: string | undefined
++): Record<string, string> {
++  const out: Record<string, string> = {};
++  if (!value) return out;
++  const body = value.replace(/^(MediaBrowser|Emby)\s+/i, '');
++  const re = /([A-Za-z]+)\s*=\s*"([^"]*)"|([A-Za-z]+)\s*=\s*([^,\s]+)/g;
++  let m: RegExpExecArray | null;
++  while ((m = re.exec(body))) {
++    const k = (m[1] ?? m[3]).toLowerCase();
++    const v = m[2] ?? m[4] ?? '';
++    out[k] = v;
++  }
++  return out;
++}
++
++export function serverIdFor(uuid: string): string {
++  return uuidToJellyfinUserId(uuid);
++}
++
++export function requestOrigin(req: Request): string {
++  const host = req.get('x-forwarded-host') || req.get('host');
++  if (host) {
++    const proto = (req.get('x-forwarded-proto') || req.protocol || 'http')
++      .split(',')[0]
++      .trim();
++    return `${proto}://${host}`;
++  }
++  if (appConfig.bootstrap.baseUrl)
++    return appConfig.bootstrap.baseUrl.replace(/\/$/, '');
++  return `http://localhost:${appConfig.bootstrap.port}`;
++}
++
++async function loadVerifiedUser(
++  uuidOrAlias: string,
++  encryptedPassword: string
++): Promise<{ uuid: string; userData: UserData } | null> {
++  let uuid = uuidOrAlias;
++  if (!isConfigUuid(uuidOrAlias)) {
++    const alias = await resolveConfigAlias(uuidOrAlias);
++    if (!alias) return null;
++    uuid = alias.uuid;
++  }
++  if (!(await UserRepository.checkUserExists(uuid))) return null;
++  const dec = decryptString(encryptedPassword);
++  if (!dec.success || dec.data == null) return null;
++  try {
++    const userData = await UserRepository.getUser(uuid, dec.data);
++    if (!userData) return null;
++    return { uuid, userData };
++  } catch (error) {
++    if (
++      error instanceof APIError &&
++      error.code === constants.ErrorCode.USER_INVALID_DETAILS
++    ) {
++      return null;
++    }
++    throw error;
++  }
++}
++
++export async function verifyCredentials(
++  uuidOrAlias: string,
++  encryptedPassword: string
++): Promise<string | null> {
++  let uuid = uuidOrAlias;
++  if (!isConfigUuid(uuidOrAlias)) {
++    const alias = await resolveConfigAlias(uuidOrAlias);
++    if (!alias) return null;
++    uuid = alias.uuid;
++  }
++  const dec = decryptString(encryptedPassword);
++  if (!dec.success || dec.data == null) return null;
++  return (await UserRepository.verifyCredentials(uuid, dec.data)) ? uuid : null;
++}
++
++interface CachedUser {
++  uuid: string;
++  parentUuid?: string;
++  version: string;
++  userData: UserData;
++  at: number;
++}
++const userCache = new Map<string, CachedUser>();
++const userInFlight = new Map<string, Promise<CachedUser | null>>();
++const USER_CACHE_MAX = 5_000;
++const USER_CACHE_TTL_MS = 5 * 60_000;
++
++function versionFor(
++  versions: Map<string, string>,
++  uuid: string,
++  parentUuid?: string
++): string {
++  const own = versions.get(uuid);
++  if (own == null) return '';
++  return parentUuid ? `${own}|${versions.get(parentUuid) ?? ''}` : own;
++}
++
++async function resolveUuid(uuidOrAlias: string): Promise<string | null> {
++  if (isConfigUuid(uuidOrAlias)) return uuidOrAlias;
++  const alias = await resolveConfigAlias(uuidOrAlias);
++  return alias?.uuid ?? null;
++}
++
++export async function resolveUserData(
++  uuidOrAlias: string,
++  encryptedPassword: string,
++  ip?: string
++): Promise<{ uuid: string; userData: UserData } | null> {
++  const uuid = await resolveUuid(uuidOrAlias);
++  if (!uuid) return null;
++  const key = `${uuid}|${encryptedPassword}`;
++
++  let entry = await freshCachedUser(key);
++  if (!entry) {
++    let inFlight = userInFlight.get(key);
++    if (!inFlight) {
++      inFlight = buildCachedUser(uuid, encryptedPassword).finally(() =>
++        userInFlight.delete(key)
++      );
++      userInFlight.set(key, inFlight);
++    }
++    entry = await inFlight;
++    if (!entry) return null;
++  }
++  const userData = structuredClone(entry.userData);
++  userData.ip = ip;
++  return { uuid: entry.uuid, userData };
++}
++
++async function freshCachedUser(key: string): Promise<CachedUser | null> {
++  const cached = userCache.get(key);
++  if (!cached) return null;
++  if (Date.now() - cached.at < USER_CACHE_TTL_MS) {
++    const versions = await JellyfinRepository.userVersions([
++      cached.uuid,
++      cached.parentUuid ?? '',
++    ]);
++    if (
++      versionFor(versions, cached.uuid, cached.parentUuid) === cached.version
++    ) {
++      return cached;
++    }
++  }
++  userCache.delete(key);
++  return null;
++}
++
++async function buildCachedUser(
++  uuid: string,
++  encryptedPassword: string
++): Promise<CachedUser | null> {
++  const now = Date.now();
++  const preVersions = await JellyfinRepository.userVersions([uuid]);
++  const verified = await loadVerifiedUser(uuid, encryptedPassword);
++  if (!verified) return null;
++  let userData = verified.userData;
++  userData.encryptedPassword = encryptedPassword;
++  userData.uuid = verified.uuid;
++  userData.ip = undefined;
++  userData = await syncUserDataUrls(userData);
++  userData = await validateConfig(userData, {
++    skipErrorsFromAddonsOrProxies: true,
++    decryptValues: true,
++  });
++
++  const parentUuid = verified.userData.parentConfig?.uuid || undefined;
++  const versions = parentUuid
++    ? await JellyfinRepository.userVersions([parentUuid])
++    : new Map<string, string>();
++  versions.set(uuid, preVersions.get(uuid) ?? '');
++
++  const entry: CachedUser = {
++    uuid: verified.uuid,
++    parentUuid,
++    version: versionFor(versions, uuid, parentUuid),
++    userData,
++    at: now,
++  };
++  const key = `${uuid}|${encryptedPassword}`;
++  if (userCache.size >= USER_CACHE_MAX) {
++    const oldest = userCache.keys().next().value;
++    if (oldest !== undefined) userCache.delete(oldest);
++  }
++  userCache.set(key, entry);
++  return entry;
++}
++
++function sendUnauthorized(res: Response, message = 'Unauthorized') {
++  res.status(401).json({ Message: message });
++}
++
++const PUBLIC = [
++  /^\/system\/info\/public$/i,
++  /^\/system\/ping$/i,
++  /^\/users\/authenticatebyname$/i,
++  /^\/users\/public$/i,
++  /^\/branding\/(configuration|css|css\.css)$/i,
++  /^\/quickconnect\/enabled$/i,
++  /^\/quickconnect\/initiate$/i,
++  /^\/quickconnect\/connect$/i,
++  /^\/quickconnect\/authorize$/i,
++  /^\/startup\//i,
++  /^\/system\/endpoint$/i,
++  /^\/items\/[^/]+\/images(\/|$)/i,
++  /^\/userimage$/i,
++];
++
++const LAZY_CONTEXT_PATHS = [/^\/items\/[^/]+\/images(\/|$)/i];
++
++async function buildContext(
++  req: Request,
++  uuid: string,
++  encryptedPassword: string,
++  mb: Record<string, string>,
++  reusableToken: string | undefined,
++  preAuthenticated: boolean
++): Promise<JellyfinRequestContext | null> {
++  const resolved = await resolveUserData(uuid, encryptedPassword, req.userIp);
++  if (!resolved) return null;
++  const baseUrl = `${requestOrigin(req)}${req.baseUrl}`.replace(/\/$/, '');
++  const apiKey =
++    reusableToken ??
++    mintToken({ u: resolved.uuid, p: encryptedPassword, d: mb.deviceid });
++  const serverId = serverIdFor(resolved.uuid);
++  return {
++    uuid: resolved.uuid,
++    encryptedPassword,
++    userData: resolved.userData,
++    userId: uuidToJellyfinUserId(resolved.uuid),
++    serverId,
++    service: new JellyfinService(resolved.userData),
++    build: { uuid: resolved.uuid, serverId },
++    baseUrl,
++    apiKey,
++    client: {
++      name: mb.client || 'Unknown',
++      device: mb.device || 'Unknown',
++      deviceId: mb.deviceid || 'unknown',
++      version: mb.version || '0',
++    },
++    preAuthenticated,
++  };
++}
++
++export const jellyfinContext: RequestHandler = async (req, res, next) => {
++  try {
++    const params = req.params as Record<string, string | undefined>;
++    const pathUuid = params.uuid;
++    const pathPassword = params.encryptedPassword;
++
++    const mb = parseMediaBrowserHeader(
++      req.get('authorization') ?? req.get('x-emby-authorization')
++    );
++    const token =
++      mb.token ||
++      req.get('x-emby-token') ||
++      req.get('x-mediabrowser-token') ||
++      (typeof req.query.api_key === 'string' ? req.query.api_key : undefined) ||
++      (typeof req.query.ApiKey === 'string' ? req.query.ApiKey : undefined);
++
++    let uuid: string | undefined;
++    let encryptedPassword: string | undefined;
++    let preAuthenticated = false;
++    let tokenPayload: TokenPayload | null = null;
++
++    if (token) tokenPayload = readToken(token);
++
++    if (pathUuid && pathPassword) {
++      if (!isEncrypted(pathPassword)) {
++        next('router');
++        return;
++      }
++      uuid = pathUuid;
++      encryptedPassword = pathPassword;
++      preAuthenticated = true;
++    } else if (tokenPayload) {
++      uuid = tokenPayload.u;
++      encryptedPassword = tokenPayload.p;
++    }
++
++    const isPublic = PUBLIC.some((re) => re.test(req.path));
++    if (!uuid || !encryptedPassword) {
++      if (isPublic) {
++        next();
++        return;
++      }
++      sendUnauthorized(res);
++      return;
++    }
++
++    const authedUuid = uuid;
++    const authedPassword = encryptedPassword;
++    const makeContext = () =>
++      buildContext(
++        req,
++        authedUuid,
++        authedPassword,
++        mb,
++        tokenPayload ? token : undefined,
++        preAuthenticated
++      );
++
++    if (LAZY_CONTEXT_PATHS.some((re) => re.test(req.path))) {
++      const verifiedUuid = await verifyCredentials(authedUuid, authedPassword);
++      if (!verifiedUuid) {
++        if (isPublic) {
++          next();
++          return;
++        }
++        sendUnauthorized(res, 'Invalid credentials');
++        return;
++      }
++      req.uuid = verifiedUuid;
++      let inFlight: Promise<JellyfinRequestContext | null> | null = null;
++      req.jfLazy = () => (inFlight ??= makeContext());
++      next();
++      return;
++    }
++
++    const ctx = await makeContext();
++    if (!ctx) {
++      if (isPublic) {
++        next();
++        return;
++      }
++      sendUnauthorized(res, 'Invalid credentials');
++      return;
++    }
++
++    req.jf = ctx;
++    req.userData = ctx.userData;
++    req.uuid = ctx.uuid;
++    next();
++  } catch (error) {
++    logger.error(
++      `jellyfin context error: ${error instanceof Error ? error.message : error}`
++    );
++    res.status(500).json({ Message: 'Internal error' });
++  }
++};
++
++export function requireContext(
++  req: Request,
++  res: Response
++): JellyfinRequestContext | null {
++  if (!req.jf) {
++    sendUnauthorized(res);
++    return null;
++  }
++  return req.jf;
++}
++
++export function jf(
++  handler: (
++    req: Request,
++    res: Response,
++    ctx: JellyfinRequestContext
++  ) => Promise<void> | void
++): RequestHandler {
++  return async (req, res, next: NextFunction) => {
++    if (!req.jf && req.jfLazy) {
++      try {
++        req.jf = (await req.jfLazy()) ?? undefined;
++        if (req.jf) req.userData = req.jf.userData;
++      } catch (error) {
++        logger.error(
++          {
++            path: req.originalUrl,
++            err: error instanceof Error ? error.message : String(error),
++          },
++          'jellyfin context hydration failed'
++        );
++        res.status(500).json({ Message: 'Internal error' });
++        return;
++      }
++    }
++    const ctx = requireContext(req, res);
++    if (!ctx) return;
++    try {
++      await handler(req, res, ctx);
++    } catch (error) {
++      const msg = error instanceof Error ? error.message : String(error);
++      logger.error(
++        { path: req.originalUrl, err: msg },
++        'jellyfin handler failed'
++      );
++      if (!res.headersSent) res.status(500).json({ Message: msg });
++      else next(error);
++    }
++  };
++}
++
++export function qs(req: Request, name: string): string | undefined {
++  const direct = req.query[name];
++  if (typeof direct === 'string') return direct;
++  const lower = name.toLowerCase();
++  for (const [k, v] of Object.entries(req.query)) {
++    if (k.toLowerCase() === lower && typeof v === 'string') return v;
++  }
++  return undefined;
++}
++
++export function qi(req: Request, name: string, fallback: number): number {
++  const v = qs(req, name);
++  if (v == null || v === '') return fallback;
++  const n = Number(v);
++  return Number.isFinite(n) ? n : fallback;
++}
++
++export function qb(req: Request, name: string): boolean | undefined {
++  const v = qs(req, name);
++  if (v == null) return undefined;
++  return v.toLowerCase() === 'true';
++}
++
++export function qlist(req: Request, name: string): string[] {
++  const v = qs(req, name);
++  if (!v) return [];
++  return v
++    .split(/[,|]/)
++    .map((s) => s.trim())
++    .filter(Boolean);
++}
+diff --git a/packages/server/src/routes/jellyfin/index.ts b/packages/server/src/routes/jellyfin/index.ts
+new file mode 100644
+index 00000000..f7128ad7
+--- /dev/null
++++ b/packages/server/src/routes/jellyfin/index.ts
+@@ -0,0 +1,66 @@
++import express, { type Router } from 'express';
++import { isEncrypted } from '@aiostreams/core';
++import { corsMiddleware } from '../../middlewares/cors.js';
++import {
++  loginRateLimiter,
++  staticRateLimiter,
++  stremioCatalogRateLimiter,
++  stremioStreamRateLimiter,
++} from '../../middlewares/ratelimit.js';
++import { jellyfinContext } from './context.js';
++import systemRouter from './system.js';
++import playbackRouter from './playback.js';
++import libraryRouter from './library.js';
++
++export function createJellyfinRouter(): Router {
++  const router = express.Router({ mergeParams: true, caseSensitive: false });
++  router.use(corsMiddleware);
++  router.use(
++    express.json({
++      limit: '1mb',
++      type: ['application/json', 'text/json', 'application/*+json'],
++    })
++  );
++  router.use(express.urlencoded({ extended: false }));
++  router.use((req, _res, next) => {
++    const p = req.params as Record<string, string | undefined>;
++    if (p.uuid && p.encryptedPassword && !isEncrypted(p.encryptedPassword)) {
++      next('router');
++      return;
++    }
++    next();
++  });
++  router.use((req, _res, next) => {
++    if (/^\/emby(\/|$)/i.test(req.url))
++      req.url = req.url.replace(/^\/emby/i, '') || '/';
++    next();
++  });
++  const CATALOG_LIKE =
++    /^\/(Users\/[^/]+\/)?Items(\/Latest|\/Resume)?$|^\/UserItems\/Resume$|^\/Shows\/NextUp$|^\/Shows\/[^/]+\/(Seasons|Episodes)$|^\/Search\/Hints$|^\/Genres$/i;
++  const STREAM_LIKE = /^\/Items\/[^/]+\/(PlaybackInfo|MediaSources)$/i;
++  const LOGIN_LIKE = /^\/Users\/AuthenticateByName$/i;
++  router.use((req, res, next) => {
++    if (LOGIN_LIKE.test(req.path) && !req.params.encryptedPassword) {
++      loginRateLimiter(req, res, next);
++    } else if (STREAM_LIKE.test(req.path)) {
++      stremioStreamRateLimiter(req, res, next);
++    } else if (CATALOG_LIKE.test(req.path)) {
++      stremioCatalogRateLimiter(req, res, next);
++    } else {
++      staticRateLimiter(req, res, next);
++    }
++  });
++  router.use(jellyfinContext);
++  router.use(systemRouter);
++  router.use(playbackRouter);
++  router.use(libraryRouter);
++  router.use((req, res) => {
++    res.status(404).json({
++      Message: `Unsupported Jellyfin endpoint: ${req.method} ${req.path}`,
++    });
++  });
++  return router;
++}
++
++export { attachJellyfinWebSocket } from './ws.js';
++export { registerJellyfinTasks } from './tasks.js';
+diff --git a/packages/server/src/routes/jellyfin/items.ts b/packages/server/src/routes/jellyfin/items.ts
+new file mode 100644
+index 00000000..1b5640b3
+--- /dev/null
++++ b/packages/server/src/routes/jellyfin/items.ts
+@@ -0,0 +1,310 @@
++import {
++  buildEpisodeItem,
++  buildMetaItem,
++  buildSeasonItem,
++  buildViewItem,
++  buildGenreItem,
++  buildPersonItem,
++  decodeJellyfinId,
++  encodeJellyfinId,
++  groupSeasons,
++  JellyfinRepository,
++  playstateToUserData,
++  stripInternal,
++  type JellyfinItem,
++  type JellyfinItemDescriptor,
++  type JellyfinPlaystateRow,
++  type MetaPreview,
++  type ParsedMeta,
++} from '@aiostreams/core';
++import type { JellyfinRequestContext } from './context.js';
++
++export interface ItemList {
++  Items: JellyfinItem[];
++  TotalRecordCount: number;
++  StartIndex: number;
++}
++
++export function list(
++  items: JellyfinItem[],
++  total?: number,
++  startIndex = 0
++): ItemList {
++  return {
++    Items: items.map(stripInternal),
++    TotalRecordCount: total ?? startIndex + items.length,
++    StartIndex: startIndex,
++  };
++}
++
++export async function attachUserData(
++  ctx: JellyfinRequestContext,
++  items: JellyfinItem[]
++): Promise<JellyfinItem[]> {
++  const ids = items
++    .filter(
++      (i) => i.Type === 'Movie' || i.Type === 'Episode' || i.Type === 'Series'
++    )
++    .map((i) => i.Id);
++  if (!ids.length) return items;
++  const states = await JellyfinRepository.getPlaystates(ctx.uuid, ids);
++  if (!states.size) return items;
++  for (const item of items) {
++    const ps = states.get(item.Id);
++    if (!ps) continue;
++    if (item.Type === 'Series') {
++      item.UserData = { ...(item.UserData as object), IsFavorite: ps.favorite };
++    } else {
++      item.UserData = playstateToUserData(
++        item.Id,
++        ps,
++        item.RunTimeTicks as number | undefined
++      );
++    }
++  }
++  return items;
++}
++
++export async function itemsFromPreviews(
++  ctx: JellyfinRequestContext,
++  previews: MetaPreview[],
++  parentId?: string
++): Promise<JellyfinItem[]> {
++  const items = previews.map((p) => buildMetaItem(ctx.build, p, { parentId }));
++  return attachUserData(ctx, items);
++}
++
++export async function viewItems(
++  ctx: JellyfinRequestContext
++): Promise<JellyfinItem[]> {
++  const catalogs = await ctx.service.getCatalogs();
++  return catalogs.map((c) => buildViewItem(ctx.build, c));
++}
++
++export async function findView(
++  ctx: JellyfinRequestContext,
++  d: { t: string; c: string }
++) {
++  return ctx.service.findCatalog(d.t, d.c);
++}
++
++export function findEpisode(
++  meta: ParsedMeta,
++  d: Extract<JellyfinItemDescriptor, { k: 'episode' }>
++) {
++  const groups = groupSeasons(meta);
++  for (const g of groups) {
++    for (const v of g.videos) {
++      if (v.id === d.v) return { group: g, video: v };
++    }
++  }
++  for (const g of groups) {
++    if (g.season !== d.s) continue;
++    const v = g.videos.find((x) => x.episode === d.e);
++    if (v) return { group: g, video: v };
++  }
++  return null;
++}
++
++export async function itemFromDescriptor(
++  ctx: JellyfinRequestContext,
++  d: JellyfinItemDescriptor,
++  opts: { playstate?: JellyfinPlaystateRow; seriesPlaystates?: boolean } = {}
++): Promise<JellyfinItem | null> {
++  switch (d.k) {
++    case 'view': {
++      const catalog = await findView(ctx, d);
++      return catalog ? buildViewItem(ctx.build, catalog) : null;
++    }
++    case 'genre':
++      return buildGenreItem(ctx.build, d.t, d.c, d.g);
++    case 'person':
++      return buildPersonItem(ctx.build, d.n);
++    case 'studio':
++      return {
++        Id: encodeJellyfinId(d),
++        Name: d.n,
++        ServerId: ctx.serverId,
++        Type: 'Studio',
++        IsFolder: true,
++      };
++    case 'movie':
++    case 'series': {
++      const meta = await ctx.service.getMetaLoose(d.t, d.i);
++      const base = meta
++        ? { ...meta, id: d.i }
++        : ({ id: d.i, type: d.t, name: d.i } as MetaPreview);
++      const item = buildMetaItem(
++        ctx.build,
++        { ...base, type: d.t },
++        { userData: opts.playstate, complete: !!meta }
++      );
++      if (!opts.playstate) await attachUserData(ctx, [item]);
++      return item;
++    }
++    case 'season': {
++      const meta = await ctx.service.getMetaLoose(d.t, d.i);
++      if (!meta) return null;
++      const seriesItem = buildMetaItem(
++        ctx.build,
++        { ...meta, type: d.t },
++        { complete: true }
++      );
++      const group = groupSeasons(meta).find((g) => g.season === d.s);
++      if (!group) return null;
++      const states = await JellyfinRepository.getPlaystates(
++        ctx.uuid,
++        group.videos.map((v) =>
++          encodeJellyfinId({
++            k: 'episode',
++            t: d.t,
++            i: d.i,
++            s: group.season,
++            e: v.episode ?? 0,
++            v: v.id,
++          })
++        )
++      );
++      return buildSeasonItem(ctx.build, meta, seriesItem, group, states);
++    }
++    case 'episode': {
++      const meta = await ctx.service.getMetaLoose(d.t, d.i);
++      if (!meta) return null;
++      const seriesItem = buildMetaItem(
++        ctx.build,
++        { ...meta, type: d.t },
++        { complete: true }
++      );
++      const found = findEpisode(meta, d);
++      const group = found?.group ?? {
++        season: d.s,
++        name: d.s === 0 ? 'Specials' : `Season ${d.s}`,
++        videos: [],
++      };
++      const video = found?.video ?? {
++        id: d.v,
++        title: `Episode ${d.e}`,
++        season: d.s,
++        episode: d.e,
++      };
++      const ps =
++        opts.playstate ??
++        (await JellyfinRepository.getPlaystate(
++          ctx.uuid,
++          encodeJellyfinId(d)
++        )) ??
++        undefined;
++      return buildEpisodeItem(ctx.build, meta, seriesItem, group, video, ps);
++    }
++  }
++}
++
++export async function itemFromId(
++  ctx: JellyfinRequestContext,
++  id: string
++): Promise<{ item: JellyfinItem; descriptor: JellyfinItemDescriptor } | null> {
++  const d = await decodeJellyfinId(id);
++  if (!d) return null;
++  const item = await itemFromDescriptor(ctx, d);
++  return item ? { item, descriptor: d } : null;
++}
++
++export async function seasonsForSeries(
++  ctx: JellyfinRequestContext,
++  d: { t: string; i: string }
++): Promise<{
++  meta: ParsedMeta;
++  seriesItem: JellyfinItem;
++  seasons: JellyfinItem[];
++} | null> {
++  const meta = await ctx.service.getMetaLoose(d.t, d.i);
++  if (!meta) return null;
++  const seriesItem = buildMetaItem(
++    ctx.build,
++    { ...meta, type: d.t },
++    { complete: true }
++  );
++  const groups = groupSeasons(meta);
++  const allEpisodeIds = groups.flatMap((g) =>
++    g.videos.map((v) =>
++      encodeJellyfinId({
++        k: 'episode',
++        t: d.t,
++        i: d.i,
++        s: g.season,
++        e: v.episode ?? 0,
++        v: v.id,
++      })
++    )
++  );
++  const states = await JellyfinRepository.getPlaystates(
++    ctx.uuid,
++    allEpisodeIds
++  );
++  const seasons = groups.map((g) =>
++    buildSeasonItem(ctx.build, meta, seriesItem, g, states)
++  );
++  return { meta, seriesItem, seasons };
++}
++
++export async function episodesForSeries(
++  ctx: JellyfinRequestContext,
++  d: { t: string; i: string },
++  season?: number
++): Promise<{
++  meta: ParsedMeta;
++  seriesItem: JellyfinItem;
++  episodes: JellyfinItem[];
++} | null> {
++  const meta = await ctx.service.getMetaLoose(d.t, d.i);
++  if (!meta) return null;
++  const seriesItem = buildMetaItem(
++    ctx.build,
++    { ...meta, type: d.t },
++    { complete: true }
++  );
++  const groups = groupSeasons(meta).filter(
++    (g) => season == null || g.season === season
++  );
++  const pairs = groups.flatMap((g) => g.videos.map((v) => ({ g, v })));
++  const ids = pairs.map(({ g, v }) =>
++    encodeJellyfinId({
++      k: 'episode',
++      t: d.t,
++      i: d.i,
++      s: g.season,
++      e: v.episode ?? 0,
++      v: v.id,
++    })
++  );
++  const states = await JellyfinRepository.getPlaystates(ctx.uuid, ids);
++  const episodes = pairs.map(({ g, v }, idx) =>
++    buildEpisodeItem(ctx.build, meta, seriesItem, g, v, states.get(ids[idx]))
++  );
++  return { meta, seriesItem, episodes };
++}
++
++export async function nextUpForSeries(
++  ctx: JellyfinRequestContext,
++  d: { t: string; i: string },
++  last?: JellyfinPlaystateRow
++): Promise<JellyfinItem | null> {
++  const res = await episodesForSeries(ctx, d);
++  if (!res) return null;
++  const eps = res.episodes.filter(
++    (e) => e.LocationType !== 'Virtual' && (e.ParentIndexNumber as number) !== 0
++  );
++  if (!eps.length) return null;
++  if (last) {
++    const idx = eps.findIndex((e) => e.Id === last.itemId);
++    if (idx >= 0) {
++      const lastUd = eps[idx].UserData as {
++        Played: boolean;
++        PlaybackPositionTicks: number;
++      };
++      if (!lastUd.Played && lastUd.PlaybackPositionTicks > 0) return eps[idx];
++      return eps[idx + 1] ?? null;
++    }
++  }
++  return eps.find((e) => !(e.UserData as { Played: boolean }).Played) ?? null;
++}
+diff --git a/packages/server/src/routes/jellyfin/library.ts b/packages/server/src/routes/jellyfin/library.ts
+new file mode 100644
+index 00000000..b43bf077
+--- /dev/null
++++ b/packages/server/src/routes/jellyfin/library.ts
+@@ -0,0 +1,1016 @@
++import { Router, type Request } from 'express';
++import {
++  collectConcurrent,
++  config as appConfig,
++  createLogger,
++  encryptString,
++} from '@aiostreams/core';
++import {
++  buildGenreItem,
++  buildMetaItem,
++  buildViewItem,
++  decodeJellyfinId,
++  encodeJellyfinId,
++  JellyfinRepository,
++  stripInternal,
++  collectionTypeFor,
++  type JellyfinItem,
++  type JellyfinItemDescriptor,
++  type MetaPreview,
++} from '@aiostreams/core';
++import {
++  jf,
++  qb,
++  qi,
++  qlist,
++  qs,
++  type JellyfinRequestContext,
++  param,
++} from './context.js';
++import {
++  attachUserData,
++  episodesForSeries,
++  itemFromDescriptor,
++  itemFromId,
++  itemsFromPreviews,
++  list,
++  nextUpForSeries,
++  seasonsForSeries,
++  viewItems,
++} from './items.js';
++
++const logger = createLogger('jellyfin');
++const router: Router = Router({ mergeParams: true });
++
++const MAX_MEDIA_SOURCES = 50;
++
++function lookup<T, R>(
++  items: readonly T[],
++  fn: (item: T) => Promise<R[]>,
++  opts: { target?: number; what: string }
++): Promise<R[]> {
++  return collectConcurrent(items, fn, {
++    concurrency: appConfig.api.jellyfinLookupConcurrency,
++    target: opts.target,
++    onError: (error) =>
++      logger.debug(
++        { err: error instanceof Error ? error.message : String(error) },
++        `skipping unresolvable ${opts.what}`
++      ),
++  });
++}
++
++function encryptToken(plain: string): string {
++  const r = encryptString(plain);
++  if (!r.success || !r.data) throw new Error('encryption failed');
++  return r.data;
++}
++
++async function views(ctx: JellyfinRequestContext) {
++  const items = await viewItems(ctx);
++  return list(items, items.length);
++}
++
++router.get(
++  ['/Users/:userId/Views', '/UserViews'],
++  jf(async (_req, res, ctx) => {
++    res.json(await views(ctx));
++  })
++);
++router.get(
++  ['/Users/:userId/GroupingOptions', '/UserViews/GroupingOptions'],
++  jf(async (_req, res, ctx) => {
++    const items = await viewItems(ctx);
++    res.json(items.map((i) => ({ Name: i.Name, Id: i.Id })));
++  })
++);
++router.get(
++  ['/Library/VirtualFolders', '/Library/MediaFolders'],
++  jf(async (req, res, ctx) => {
++    const items = await viewItems(ctx);
++    if (/MediaFolders/i.test(req.path)) {
++      res.json(list(items, items.length));
++      return;
++    }
++    res.json(
++      items.map((i) => ({
++        Name: i.Name,
++        Locations: [i.Path],
++        CollectionType: i.CollectionType ?? null,
++        LibraryOptions: {
++          Enabled: true,
++          EnableRealtimeMonitor: false,
++          PathInfos: [],
++        },
++        ItemId: i.Id,
++        PrimaryImageItemId: i.Id,
++        RefreshStatus: 'Idle',
++      }))
++    );
++  })
++);
++
++type ItemTypeFilter = Set<string> | null;
++
++function includeTypes(req: Request): ItemTypeFilter {
++  const types = qlist(req, 'IncludeItemTypes');
++  return types.length ? new Set(types.map((t) => t.toLowerCase())) : null;
++}
++
++function filterByType(
++  items: JellyfinItem[],
++  types: ItemTypeFilter
++): JellyfinItem[] {
++  if (!types) return items;
++  return items.filter((i) => types.has(String(i.Type).toLowerCase()));
++}
++
++function stremioTypesFor(types: ItemTypeFilter): string[] | undefined {
++  if (!types) return undefined;
++  const out = new Set<string>();
++  if (types.has('movie')) out.add('movie');
++  if (types.has('series') || types.has('episode') || types.has('season')) {
++    out.add('series');
++    out.add('anime');
++  }
++  return out.size ? [...out] : undefined;
++}
++
++function applyUserFilters(req: Request, items: JellyfinItem[]): JellyfinItem[] {
++  const filters = qlist(req, 'Filters').map((f) => f.toLowerCase());
++  const isPlayed = qb(req, 'IsPlayed');
++  const isFavorite = qb(req, 'IsFavorite');
++  let out = items;
++  const ud = (i: JellyfinItem) =>
++    i.UserData as {
++      Played: boolean;
++      IsFavorite: boolean;
++      PlaybackPositionTicks: number;
++    };
++  if (filters.includes('isplayed') || isPlayed === true)
++    out = out.filter((i) => ud(i).Played);
++  if (filters.includes('isunplayed') || isPlayed === false)
++    out = out.filter((i) => !ud(i).Played);
++  if (filters.includes('isfavorite') || isFavorite === true)
++    out = out.filter((i) => ud(i).IsFavorite);
++  if (filters.includes('isresumable'))
++    out = out.filter((i) => ud(i).PlaybackPositionTicks > 0);
++  return out;
++}
++
++function applySort(req: Request, items: JellyfinItem[]): JellyfinItem[] {
++  const sortBy = qlist(req, 'SortBy').map((s) => s.toLowerCase());
++  const desc = (qs(req, 'SortOrder') ?? '').toLowerCase() === 'descending';
++  if (!sortBy.length || sortBy[0] === 'default') return items;
++  const key = sortBy[0];
++  const val = (i: JellyfinItem): number | string => {
++    switch (key) {
++      case 'sortname':
++      case 'name':
++        return String(i.SortName ?? i.Name ?? '').toLowerCase();
++      case 'productionyear':
++      case 'premieredate':
++        return Number(i.ProductionYear ?? 0);
++      case 'communityrating':
++        return Number(i.CommunityRating ?? 0);
++      case 'runtime':
++        return Number(i.RunTimeTicks ?? 0);
++      case 'random':
++        return Math.random();
++      case 'datecreated':
++      case 'dateplayed':
++      case 'dateadded':
++      default:
++        return 0;
++    }
++  };
++  if (
++    ['datecreated', 'dateplayed', 'dateadded', 'datelastcontentadded'].includes(
++      key
++    )
++  )
++    return items;
++  const sorted = [...items].sort((a, b) => {
++    const av = val(a);
++    const bv = val(b);
++    if (av < bv) return -1;
++    if (av > bv) return 1;
++    return 0;
++  });
++  return desc ? sorted.reverse() : sorted;
++}
++
++async function itemsFromPlaystates(
++  ctx: JellyfinRequestContext,
++  rows: Awaited<ReturnType<typeof JellyfinRepository.listFavorites>>,
++  limit: number
++): Promise<JellyfinItem[]> {
++  return lookup(
++    rows.slice(0, limit),
++    async (row) => {
++      const item = await itemFromDescriptor(ctx, row.payload, {
++        playstate: row,
++      });
++      return item ? [item] : [];
++    },
++    { what: 'item' }
++  );
++}
++
++async function handleItemsQuery(req: Request, ctx: JellyfinRequestContext) {
++  const startIndex = Math.max(0, qi(req, 'StartIndex', 0));
++  const limit = Math.min(Math.max(1, qi(req, 'Limit', 100)), 500);
++  const parentId = qs(req, 'ParentId');
++  const ids = qlist(req, 'Ids');
++  const searchTerm = qs(req, 'SearchTerm')?.trim();
++  const types = includeTypes(req);
++  const genres = qlist(req, 'Genres');
++  const genreIds = qlist(req, 'GenreIds');
++  const filters = qlist(req, 'Filters').map((f) => f.toLowerCase());
++  const wantsFavorites =
++    filters.includes('isfavorite') || qb(req, 'IsFavorite') === true;
++  const wantsPlayed =
++    filters.includes('isplayed') || qb(req, 'IsPlayed') === true;
++  const wantsResumable = filters.includes('isresumable');
++  const recursive = qb(req, 'Recursive') ?? false;
++  const personIds = qlist(req, 'PersonIds');
++
++  if (ids.length) {
++    const items = await lookup(
++      ids.slice(0, 200),
++      async (id) => {
++        const r = await itemFromId(ctx, id);
++        return r ? [r.item] : [];
++      },
++      { what: 'id' }
++    );
++    return list(filterByType(items, types), items.length, 0);
++  }
++
++  let parent: JellyfinItemDescriptor | null = null;
++  if (parentId) parent = await decodeJellyfinId(parentId);
++
++  if (parent?.k === 'series') {
++    if (types?.has('episode') || recursive) {
++      const r = await episodesForSeries(ctx, parent);
++      const eps = applyUserFilters(req, r?.episodes ?? []);
++      return list(
++        filterByType(eps, types ?? new Set(['episode'])).slice(
++          startIndex,
++          startIndex + limit
++        ),
++        eps.length,
++        startIndex
++      );
++    }
++    const r = await seasonsForSeries(ctx, parent);
++    const seasons = r?.seasons ?? [];
++    return list(
++      seasons.slice(startIndex, startIndex + limit),
++      seasons.length,
++      startIndex
++    );
++  }
++  if (parent?.k === 'season') {
++    const r = await episodesForSeries(ctx, parent, parent.s);
++    const eps = applyUserFilters(req, r?.episodes ?? []);
++    return list(
++      eps.slice(startIndex, startIndex + limit),
++      eps.length,
++      startIndex
++    );
++  }
++  if (parent?.k === 'person' || personIds.length) {
++    const name = parent?.k === 'person' ? parent.n : null;
++    const previews = name
++      ? await ctx.service.search(name, stremioTypesFor(types), limit)
++      : [];
++    const items = await itemsFromPreviews(ctx, previews);
++    return list(filterByType(items, types), items.length, 0);
++  }
++
++  if (wantsFavorites || wantsPlayed || wantsResumable) {
++    const kinds = types
++      ? [...types].map((t) =>
++          t === 'movie'
++            ? 'movie'
++            : t === 'episode'
++              ? 'episode'
++              : t === 'series'
++                ? 'series'
++                : t
++        )
++      : undefined;
++    const rows = wantsFavorites
++      ? await JellyfinRepository.listFavorites(ctx.uuid, kinds)
++      : wantsResumable
++        ? await JellyfinRepository.listResume(ctx.uuid, limit + startIndex)
++        : await JellyfinRepository.listPlayed(ctx.uuid, kinds);
++    const items = await itemsFromPlaystates(ctx, rows, startIndex + limit);
++    const page = applySort(req, filterByType(items, types)).slice(
++      startIndex,
++      startIndex + limit
++    );
++    return list(page, items.length, startIndex);
++  }
++
++  const genreFromIds = genreIds.length
++    ? await decodeJellyfinId(genreIds[0])
++    : null;
++  const genre =
++    genres[0] ?? (genreFromIds?.k === 'genre' ? genreFromIds.g : undefined);
++
++  let catalogDesc: { t: string; c: string } | null = null;
++  if (parent?.k === 'view') catalogDesc = parent;
++  else if (parent?.k === 'genre') catalogDesc = parent;
++  else if (genreFromIds?.k === 'genre' && genreFromIds.c)
++    catalogDesc = genreFromIds;
++
++  if (catalogDesc) {
++    const catalog = await ctx.service.findCatalog(catalogDesc.t, catalogDesc.c);
++    if (!catalog) return list([], 0, startIndex);
++    const g = parent?.k === 'genre' ? parent.g : genre;
++    const page = await ctx.service.getCatalogPage(catalog, {
++      startIndex,
++      limit,
++      search: searchTerm,
++      genre: g,
++    });
++    const items = await itemsFromPreviews(ctx, page.items, parentId);
++    const filtered = applySort(
++      req,
++      applyUserFilters(req, filterByType(items, types))
++    );
++    const total = page.hasMore
++      ? startIndex + filtered.length + limit
++      : startIndex + filtered.length;
++    return list(filtered, total, startIndex);
++  }
++
++  if (searchTerm) {
++    const previews = await ctx.service.search(
++      searchTerm,
++      stremioTypesFor(types),
++      startIndex + limit
++    );
++    const items = await itemsFromPreviews(ctx, previews);
++    const filtered = filterByType(items, types);
++    return list(
++      filtered.slice(startIndex, startIndex + limit),
++      filtered.length,
++      startIndex
++    );
++  }
++
++  if (!parentId && !recursive) {
++    return views(ctx);
++  }
++
++  if (!parentId && recursive) {
++    const catalogs = await ctx.service.getCatalogs();
++    const wanted = stremioTypesFor(types);
++    const usable = catalogs.filter((c) => !wanted || wanted.includes(c.type));
++    const items: JellyfinItem[] = [];
++    let offset = 0;
++    for (const catalog of usable) {
++      if (items.length >= limit) break;
++      const page = await ctx.service.getCatalogPage(catalog, {
++        startIndex: Math.max(0, startIndex - offset),
++        limit: limit - items.length + Math.max(0, offset - startIndex),
++      });
++      const viewId = encodeJellyfinId({
++        k: 'view',
++        t: catalog.type,
++        c: catalog.id,
++      });
++      const built = await itemsFromPreviews(ctx, page.items, viewId);
++      for (const it of built) {
++        if (offset >= startIndex && items.length < limit) items.push(it);
++        offset++;
++      }
++      if (page.hasMore) offset += 1;
++      if (page.hasMore && items.length >= limit) {
++        return list(
++          filterByType(items, types),
++          startIndex + items.length + limit,
++          startIndex
++        );
++      }
++    }
++    return list(
++      filterByType(items, types),
++      startIndex + items.length,
++      startIndex
++    );
++  }
++
++  return list([], 0, startIndex);
++}
++
++router.get(
++  ['/Users/:userId/Items', '/Items'],
++  jf(async (req, res, ctx) => {
++    res.json(await handleItemsQuery(req, ctx));
++  })
++);
++
++router.get(
++  ['/Users/:userId/Items/Latest', '/Items/Latest'],
++  jf(async (req, res, ctx) => {
++    const limit = Math.min(Math.max(1, qi(req, 'Limit', 16)), 100);
++    const parentId = qs(req, 'ParentId');
++    const types = includeTypes(req);
++    let items: JellyfinItem[] = [];
++    if (parentId) {
++      const d = await decodeJellyfinId(parentId);
++      if (d?.k === 'view') {
++        const catalog = await ctx.service.findCatalog(d.t, d.c);
++        if (catalog) {
++          const page = await ctx.service.getCatalogPage(catalog, {
++            startIndex: 0,
++            limit,
++          });
++          items = await itemsFromPreviews(ctx, page.items, parentId);
++        }
++      }
++    } else {
++      const catalogs = await ctx.service.getCatalogs();
++      const wanted = stremioTypesFor(types);
++      const usable = catalogs.filter((c) => !wanted || wanted.includes(c.type));
++      const perCatalog = Math.max(
++        4,
++        Math.ceil(limit / Math.max(1, usable.length))
++      );
++      items = await lookup(
++        usable,
++        async (catalog) => {
++          const page = await ctx.service.getCatalogPage(catalog, {
++            startIndex: 0,
++            limit: perCatalog,
++          });
++          const built = await itemsFromPreviews(
++            ctx,
++            page.items,
++            encodeJellyfinId({ k: 'view', t: catalog.type, c: catalog.id })
++          );
++          return filterByType(built, types);
++        },
++        { target: limit, what: 'catalog in Latest' }
++      );
++    }
++    res.json(filterByType(items, types).slice(0, limit).map(stripInternal));
++  })
++);
++
++router.get(
++  ['/Users/:userId/Items/Resume', '/UserItems/Resume'],
++  jf(async (req, res, ctx) => {
++    const limit = Math.min(Math.max(1, qi(req, 'Limit', 12)), 100);
++    const startIndex = Math.max(0, qi(req, 'StartIndex', 0));
++    const types = includeTypes(req);
++    const mediaTypes = qlist(req, 'MediaTypes').map((m) => m.toLowerCase());
++    if (mediaTypes.length && !mediaTypes.includes('video')) {
++      res.json(list([], 0, startIndex));
++      return;
++    }
++    const kinds = types
++      ? [...types].filter((t) => t === 'movie' || t === 'episode')
++      : ['movie', 'episode'];
++    const rows = await JellyfinRepository.listResume(
++      ctx.uuid,
++      startIndex + limit,
++      kinds.length ? kinds : ['movie', 'episode']
++    );
++    const items = await itemsFromPlaystates(ctx, rows, startIndex + limit);
++    res.json(
++      list(
++        items.slice(startIndex, startIndex + limit),
++        items.length,
++        startIndex
++      )
++    );
++  })
++);
++
++router.get(
++  '/Shows/NextUp',
++  jf(async (req, res, ctx) => {
++    const limit = Math.min(Math.max(1, qi(req, 'Limit', 12)), 50);
++    const seriesId = qs(req, 'SeriesId');
++    const items: JellyfinItem[] = [];
++    if (seriesId) {
++      const d = await decodeJellyfinId(seriesId);
++      if (d && (d.k === 'series' || d.k === 'movie')) {
++        const rows = await JellyfinRepository.listForSeries(ctx.uuid, d.t, d.i);
++        rows.sort((a, b) => b.updatedAt - a.updatedAt);
++        const next = await nextUpForSeries(ctx, d, rows[0]);
++        if (next) items.push(next);
++      }
++    } else {
++      const recent = await JellyfinRepository.listRecentEpisodesBySeries(
++        ctx.uuid,
++        limit * 2
++      );
++      const candidates = recent.filter(
++        (row): row is typeof row & { payload: { t: string; i: string } } =>
++          row.payload.k === 'episode'
++      );
++      const nexts = await lookup(
++        candidates,
++        async (row) => {
++          const next = await nextUpForSeries(
++            ctx,
++            { t: row.payload.t, i: row.payload.i },
++            row
++          );
++          return next && !(next.UserData as { Played: boolean }).Played
++            ? [next]
++            : [];
++        },
++        { target: limit, what: 'series in Next Up' }
++      );
++      items.push(...nexts.slice(0, limit));
++    }
++    res.json(list(items, items.length, 0));
++  })
++);
++
++router.get(
++  '/Shows/Upcoming',
++  jf(async (_req, res) => {
++    res.json(list([], 0, 0));
++  })
++);
++
++router.get(
++  '/Shows/:seriesId/Seasons',
++  jf(async (req, res, ctx) => {
++    const d = await decodeJellyfinId(param(req, 'seriesId'));
++    if (!d || (d.k !== 'series' && d.k !== 'movie')) {
++      res.status(404).json({ Message: 'Series not found' });
++      return;
++    }
++    const r = await seasonsForSeries(ctx, d);
++    const seasons = r?.seasons ?? [];
++    res.json(list(seasons, seasons.length, 0));
++  })
++);
++
++router.get(
++  '/Shows/:seriesId/Episodes',
++  jf(async (req, res, ctx) => {
++    const d = await decodeJellyfinId(param(req, 'seriesId'));
++    if (!d || (d.k !== 'series' && d.k !== 'movie')) {
++      res.status(404).json({ Message: 'Series not found' });
++      return;
++    }
++    let season: number | undefined;
++    const seasonId = qs(req, 'SeasonId');
++    if (seasonId) {
++      const sd = await decodeJellyfinId(seasonId);
++      if (sd?.k === 'season') season = sd.s;
++    }
++    const seasonNum = qs(req, 'Season');
++    if (season == null && seasonNum != null && seasonNum !== '')
++      season = Number(seasonNum);
++    const r = await episodesForSeries(ctx, d, season);
++    let eps = r?.episodes ?? [];
++    const startItemId = qs(req, 'StartItemId');
++    if (startItemId) {
++      const idx = eps.findIndex((e) => e.Id === startItemId);
++      if (idx >= 0) eps = eps.slice(idx);
++    }
++    const adjacentTo = qs(req, 'AdjacentTo');
++    if (adjacentTo) {
++      const idx = eps.findIndex((e) => e.Id === adjacentTo);
++      if (idx >= 0) eps = eps.slice(Math.max(0, idx - 1), idx + 2);
++    }
++    const startIndex = Math.max(0, qi(req, 'StartIndex', 0));
++    const limit = Math.min(Math.max(1, qi(req, 'Limit', 1000)), 2000);
++    res.json(
++      list(eps.slice(startIndex, startIndex + limit), eps.length, startIndex)
++    );
++  })
++);
++
++async function sendItem(
++  req: Request,
++  res: import('express').Response,
++  ctx: JellyfinRequestContext,
++  id: string
++) {
++  const r = await itemFromId(ctx, id);
++  if (!r) {
++    res.status(404).json({ Message: 'Item not found' });
++    return;
++  }
++  const { item, descriptor } = r;
++  const wantsSources = qlist(req, 'Fields').some(
++    (f) => f.toLowerCase() === 'mediasources'
++  );
++  const target = !wantsSources
++    ? null
++    : descriptor.k === 'movie'
++      ? {
++          type: descriptor.t,
++          videoId: await ctx.service.resolveVideoId(descriptor.t, descriptor.i),
++        }
++      : descriptor.k === 'episode'
++        ? { type: descriptor.t, videoId: descriptor.v }
++        : null;
++  if (target) {
++    try {
++      const { sources } = await ctx.service.buildMediaSources(
++        target.type,
++        target.videoId,
++        {
++          baseUrl: ctx.baseUrl,
++          itemId: item.Id,
++          apiKey: ctx.apiKey,
++          encrypt: encryptToken,
++          runtimeTicks: item.RunTimeTicks as number | undefined,
++        }
++      );
++      const capped = sources.slice(0, MAX_MEDIA_SOURCES);
++      if (capped.length) {
++        capped[0] = { ...capped[0], Id: item.Id, ETag: item.Id };
++        item.MediaSources = capped;
++        item.MediaStreams = capped[0].MediaStreams;
++        item.Container = capped[0].Container;
++      } else {
++        item.MediaSources = [
++          {
++            Id: item.Id,
++            ETag: item.Id,
++            Name: 'No streams found',
++            Path: `/aiostreams/${item.Id}`,
++            Protocol: 'File',
++            Type: 'Default',
++            SupportsDirectPlay: true,
++            SupportsDirectStream: true,
++            SupportsTranscoding: false,
++            MediaStreams: [],
++            Formats: [],
++          },
++        ];
++      }
++    } catch (e) {}
++  }
++  res.json(stripInternal(item));
++}
++
++const RESERVED_ITEM_IDS =
++  /^(Filters2?|Counts|Latest|Resume|Intros|Root|Suggestions)$/i;
++router.get(
++  ['/Users/:userId/Items/:itemId', '/Items/:itemId'],
++  (req, _res, next) =>
++    RESERVED_ITEM_IDS.test(param(req, 'itemId')) ? next('route') : next(),
++  jf(async (req, res, ctx) => {
++    await sendItem(req, res, ctx, param(req, 'itemId'));
++  })
++);
++
++router.get(
++  '/Items/:itemId/Ancestors',
++  jf(async (req, res, ctx) => {
++    const d = await decodeJellyfinId(param(req, 'itemId'));
++    const out: JellyfinItem[] = [];
++    if (d?.k === 'episode') {
++      const season = await itemFromDescriptor(ctx, {
++        k: 'season',
++        t: d.t,
++        i: d.i,
++        s: d.s,
++      });
++      const series = await itemFromDescriptor(ctx, {
++        k: 'series',
++        t: d.t,
++        i: d.i,
++      });
++      if (season) out.push(season);
++      if (series) out.push(series);
++    } else if (d?.k === 'season') {
++      const series = await itemFromDescriptor(ctx, {
++        k: 'series',
++        t: d.t,
++        i: d.i,
++      });
++      if (series) out.push(series);
++    }
++    res.json(out.map(stripInternal));
++  })
++);
++
++router.get(
++  [
++    '/Items/:itemId/Similar',
++    '/Movies/:itemId/Similar',
++    '/Shows/:itemId/Similar',
++  ],
++  jf(async (req, res, ctx) => {
++    const d = await decodeJellyfinId(param(req, 'itemId'));
++    const limit = Math.min(Math.max(1, qi(req, 'Limit', 12)), 50);
++    if (!d || (d.k !== 'movie' && d.k !== 'series')) {
++      res.json(list([], 0, 0));
++      return;
++    }
++    const meta = await ctx.service.getMetaLoose(d.t, d.i);
++    const genre = (meta?.genres ?? [])[0];
++    if (!genre) {
++      res.json(list([], 0, 0));
++      return;
++    }
++    const catalogs = await ctx.service.getCatalogs();
++    for (const catalog of catalogs) {
++      if (catalog.type !== d.t) continue;
++      const opts =
++        (catalog.extra ?? []).find((e) => e.name === 'genre')?.options ?? [];
++      if (!opts.includes(genre)) continue;
++      const page = await ctx.service.getCatalogPage(catalog, {
++        startIndex: 0,
++        limit: limit + 1,
++        genre,
++      });
++      const items = (
++        await itemsFromPreviews(
++          ctx,
++          page.items.filter((p) => p.id !== d.i)
++        )
++      ).slice(0, limit);
++      res.json(list(items, items.length, 0));
++      return;
++    }
++    res.json(list([], 0, 0));
++  })
++);
++
++router.get(
++  '/Movies/Recommendations',
++  jf(async (req, res, ctx) => {
++    const limit = Math.min(Math.max(1, qi(req, 'ItemLimit', 8)), 20);
++    const catalogs = (await ctx.service.getCatalogs())
++      .filter((c) => c.type === 'movie')
++      .slice(0, 3);
++    const out: {
++      Items: JellyfinItem[];
++      RecommendationType: string;
++      BaselineItemName: string;
++      CategoryId: string;
++    }[] = [];
++    for (const catalog of catalogs) {
++      const page = await ctx.service.getCatalogPage(catalog, {
++        startIndex: 0,
++        limit,
++      });
++      const items = await itemsFromPreviews(ctx, page.items);
++      out.push({
++        Items: items.map(stripInternal),
++        RecommendationType: 'SimilarToRecentlyPlayed',
++        BaselineItemName: catalog.name,
++        CategoryId: encodeJellyfinId({
++          k: 'view',
++          t: catalog.type,
++          c: catalog.id,
++        }),
++      });
++    }
++    res.json(out);
++  })
++);
++
++for (const p of [
++  '/Items/:itemId/ThemeMedia',
++  '/Items/:itemId/ThemeSongs',
++  '/Items/:itemId/ThemeVideos',
++]) {
++  router.get(
++    p,
++    jf(async (req, res) => {
++      const empty = {
++        Items: [],
++        TotalRecordCount: 0,
++        StartIndex: 0,
++        OwnerId: param(req, 'itemId'),
++      };
++      if (/ThemeMedia/.test(p))
++        res.json({
++          ThemeVideosResult: empty,
++          ThemeSongsResult: empty,
++          SoundtrackSongsResult: empty,
++        });
++      else res.json(empty);
++    })
++  );
++}
++router.get(
++  [
++    '/Items/:itemId/SpecialFeatures',
++    '/Users/:userId/Items/:itemId/SpecialFeatures',
++    '/Users/:userId/Items/:itemId/LocalTrailers',
++    '/Items/:itemId/LocalTrailers',
++    '/Users/:userId/Items/:itemId/Intros',
++    '/Items/:itemId/Intros',
++  ],
++  jf(async (req, res) => {
++    if (/Intros/.test(req.path))
++      res.json({ Items: [], TotalRecordCount: 0, StartIndex: 0 });
++    else res.json([]);
++  })
++);
++router.get(
++  '/MediaSegments/:itemId',
++  jf(async (_req, res) => {
++    res.json({ Items: [], TotalRecordCount: 0, StartIndex: 0 });
++  })
++);
++
++router.get(
++  '/Genres',
++  jf(async (req, res, ctx) => {
++    const parentId = qs(req, 'ParentId');
++    const catalogs = await ctx.service.getCatalogs();
++    const genresOut: JellyfinItem[] = [];
++    const seen = new Set<string>();
++    let scoped = catalogs;
++    if (parentId) {
++      const d = await decodeJellyfinId(parentId);
++      if (d?.k === 'view')
++        scoped = catalogs.filter((c) => c.type === d.t && c.id === d.c);
++    }
++    for (const catalog of scoped) {
++      for (const g of await ctx.service.getCatalogGenres(catalog)) {
++        const key = `${catalog.type}|${g}`;
++        if (seen.has(key)) continue;
++        seen.add(key);
++        genresOut.push(buildGenreItem(ctx.build, catalog.type, catalog.id, g));
++      }
++    }
++    res.json(list(genresOut, genresOut.length, 0));
++  })
++);
++router.get(
++  '/Genres/:name',
++  jf(async (req, res, ctx) => {
++    res.json(
++      stripInternal(
++        buildGenreItem(
++          ctx.build,
++          'movie',
++          '',
++          decodeURIComponent(param(req, 'name'))
++        )
++      )
++    );
++  })
++);
++
++router.get(
++  ['/Items/Filters', '/Items/Filters2'],
++  jf(async (req, res, ctx) => {
++    const parentId = qs(req, 'ParentId');
++    const catalogs = await ctx.service.getCatalogs();
++    let scoped = catalogs;
++    if (parentId) {
++      const d = await decodeJellyfinId(parentId);
++      if (d?.k === 'view')
++        scoped = catalogs.filter((c) => c.type === d.t && c.id === d.c);
++    }
++    const genres: { Name: string; Id: string }[] = [];
++    const seen = new Set<string>();
++    for (const catalog of scoped) {
++      for (const g of await ctx.service.getCatalogGenres(catalog)) {
++        if (seen.has(g)) continue;
++        seen.add(g);
++        genres.push({
++          Name: g,
++          Id: encodeJellyfinId({
++            k: 'genre',
++            t: catalog.type,
++            c: catalog.id,
++            g,
++          }),
++        });
++      }
++    }
++    if (/Filters2/i.test(req.path)) {
++      res.json({ Genres: genres, Tags: [] });
++    } else {
++      res.json({
++        Genres: genres.map((g) => g.Name),
++        Tags: [],
++        OfficialRatings: [],
++        Years: [],
++      });
++    }
++  })
++);
++
++router.get(
++  '/Items/Counts',
++  jf(async (_req, res) => {
++    res.json({
++      MovieCount: 0,
++      SeriesCount: 0,
++      EpisodeCount: 0,
++      ArtistCount: 0,
++      ProgramCount: 0,
++      TrailerCount: 0,
++      SongCount: 0,
++      AlbumCount: 0,
++      MusicVideoCount: 0,
++      BoxSetCount: 0,
++      BookCount: 0,
++      ItemCount: 0,
++    });
++  })
++);
++
++router.get(
++  '/Search/Hints',
++  jf(async (req, res, ctx) => {
++    const term = (qs(req, 'SearchTerm') ?? qs(req, 'searchTerm') ?? '').trim();
++    const limit = Math.min(Math.max(1, qi(req, 'Limit', 20)), 50);
++    const types = includeTypes(req);
++    if (!term) {
++      res.json({ SearchHints: [], TotalRecordCount: 0 });
++      return;
++    }
++    const previews = await ctx.service.search(
++      term,
++      stremioTypesFor(types),
++      limit
++    );
++    const items = filterByType(await itemsFromPreviews(ctx, previews), types);
++    res.json({
++      SearchHints: items.map((i) => ({
++        ItemId: i.Id,
++        Id: i.Id,
++        Name: i.Name,
++        Type: i.Type,
++        MediaType: i.MediaType ?? 'Video',
++        ProductionYear: i.ProductionYear,
++        PrimaryImageTag: (i.ImageTags as Record<string, string>)?.Primary,
++        BackdropImageTag: (i.BackdropImageTags as string[])?.[0],
++        BackdropImageItemId: i.Id,
++        PrimaryImageAspectRatio: i.PrimaryImageAspectRatio,
++        RunTimeTicks: i.RunTimeTicks,
++        IsFolder: i.IsFolder,
++      })),
++      TotalRecordCount: items.length,
++    });
++  })
++);
++
++router.get(
++  '/Persons/:name',
++  jf(async (req, res, ctx) => {
++    const item = await itemFromDescriptor(ctx, {
++      k: 'person',
++      n: decodeURIComponent(param(req, 'name')),
++    });
++    res.json(item ? stripInternal(item) : { Message: 'Not found' });
++  })
++);
++
++async function toggleFavorite(
++  ctx: JellyfinRequestContext,
++  itemId: string,
++  favorite: boolean
++) {
++  const d = await decodeJellyfinId(itemId);
++  if (!d) return null;
++  const row = await JellyfinRepository.upsertPlaystate(
++    ctx.uuid,
++    itemId.replace(/-/g, '').toLowerCase(),
++    d,
++    { favorite }
++  );
++  return row;
++}
++
++router.post(
++  ['/Users/:userId/FavoriteItems/:itemId', '/UserFavoriteItems/:itemId'],
++  jf(async (req, res, ctx) => {
++    const row = await toggleFavorite(ctx, param(req, 'itemId'), true);
++    if (!row) {
++      res.status(404).json({ Message: 'Item not found' });
++      return;
++    }
++    const item = await itemFromDescriptor(ctx, row.payload, { playstate: row });
++    res.json(item?.UserData ?? { IsFavorite: true });
++  })
++);
++router.delete(
++  ['/Users/:userId/FavoriteItems/:itemId', '/UserFavoriteItems/:itemId'],
++  jf(async (req, res, ctx) => {
++    const row = await toggleFavorite(ctx, param(req, 'itemId'), false);
++    if (!row) {
++      res.status(404).json({ Message: 'Item not found' });
++      return;
++    }
++    const item = await itemFromDescriptor(ctx, row.payload, { playstate: row });
++    res.json(item?.UserData ?? { IsFavorite: false });
++  })
++);
++
++export default router;
+diff --git a/packages/server/src/routes/jellyfin/playback.ts b/packages/server/src/routes/jellyfin/playback.ts
+new file mode 100644
+index 00000000..941630c2
+--- /dev/null
++++ b/packages/server/src/routes/jellyfin/playback.ts
+@@ -0,0 +1,825 @@
++import { Router, type Request, type Response } from 'express';
++import { pipeline } from 'stream/promises';
++import { Readable } from 'stream';
++import {
++  config as appConfig,
++  createLogger,
++  decodeJellyfinId,
++  decryptString,
++  encryptString,
++  JellyfinRepository,
++  makeRequest,
++  recallImages,
++  rememberImages,
++  parseRuntimeToTicks,
++  type ItemImages,
++  type JellyfinItemDescriptor,
++  type PlayableStreamRecord,
++  type RememberedImages,
++} from '@aiostreams/core';
++import { jf, qs, type JellyfinRequestContext, param } from './context.js';
++import { isRelayLoop } from './relay-target.js';
++
++const logger = createLogger('jellyfin');
++const router: Router = Router({ mergeParams: true });
++
++const RELAY_OPTIONS = { ignoreRecursion: true } as const;
++
++let selfOriginsMemo: Set<string> | null = null;
++function selfOrigins(): Set<string> {
++  if (selfOriginsMemo) return selfOriginsMemo;
++  const origins = new Set<string>();
++  for (const candidate of [
++    appConfig.bootstrap.baseUrl,
++    appConfig.bootstrap.internalUrl,
++    `http://localhost:${appConfig.bootstrap.port}`,
++  ]) {
++    if (!candidate) continue;
++    try {
++      origins.add(new URL(candidate).origin);
++    } catch {}
++  }
++  selfOriginsMemo = origins;
++  return origins;
++}
++
++async function relay(url: string, headers?: Record<string, string>) {
++  if (isRelayLoop(url, selfOrigins())) {
++    throw new Error('relay target loops back to this server');
++  }
++  const timeout = appConfig.api.jellyfinRelayTimeout;
++  const controller = new AbortController();
++  const timer = setTimeout(() => controller.abort(), timeout);
++  try {
++    return await makeRequest(url, {
++      ...RELAY_OPTIONS,
++      timeout,
++      signal: controller.signal,
++      headers,
++    });
++  } finally {
++    clearTimeout(timer);
++  }
++}
++
++function encrypt(plain: string): string {
++  const r = encryptString(plain);
++  if (!r.success || !r.data) throw new Error('encryption failed');
++  return r.data;
++}
++
++function decrypt(token: string): string | null {
++  const r = decryptString(token);
++  return r.success && r.data != null ? r.data : null;
++}
++
++async function playTarget(
++  ctx: JellyfinRequestContext,
++  d: JellyfinItemDescriptor
++): Promise<{ type: string; videoId: string; seriesId?: string } | null> {
++  if (d.k === 'movie')
++    return { type: d.t, videoId: await ctx.service.resolveVideoId(d.t, d.i) };
++  if (d.k === 'episode') return { type: d.t, videoId: d.v, seriesId: d.i };
++  if (d.k === 'series')
++    return {
++      type: d.t,
++      videoId: await ctx.service.resolveVideoId(d.t, d.i),
++      seriesId: d.i,
++    };
++  return null;
++}
++
++async function runtimeTicksFor(
++  ctx: JellyfinRequestContext,
++  d: JellyfinItemDescriptor
++): Promise<number | undefined> {
++  if (d.k !== 'movie' && d.k !== 'episode' && d.k !== 'series')
++    return undefined;
++  const meta = await ctx.service.getMetaLoose(d.t, d.i).catch(() => null);
++  return parseRuntimeToTicks(meta?.runtime);
++}
++
++async function playbackInfo(
++  req: Request,
++  res: Response,
++  ctx: JellyfinRequestContext
++) {
++  const itemId = param(req, 'itemId');
++  const d = await decodeJellyfinId(itemId);
++  const target = d ? await playTarget(ctx, d) : null;
++  if (!d || !target) {
++    res
++      .status(404)
++      .json({ MediaSources: [], PlaySessionId: '', ErrorCode: 'NotAllowed' });
++    return;
++  }
++  const requestedSource =
++    qs(req, 'MediaSourceId') ??
++    (req.body as Record<string, unknown> | undefined)?.MediaSourceId;
++  const runtimeTicks = await runtimeTicksFor(ctx, d);
++  const { sources, errors } = await ctx.service.buildMediaSources(
++    target.type,
++    target.videoId,
++    {
++      baseUrl: ctx.baseUrl,
++      itemId: itemId.replace(/-/g, '').toLowerCase(),
++      apiKey: ctx.apiKey,
++      encrypt,
++      runtimeTicks,
++    }
++  );
++  const normalizedItemId = itemId.replace(/-/g, '').toLowerCase();
++  let out = sources.slice(0, 50);
++  const specific =
++    typeof requestedSource === 'string' &&
++    requestedSource &&
++    requestedSource.replace(/-/g, '').toLowerCase() !== normalizedItemId;
++  if (specific) {
++    const picked = sources.filter((s) => s.Id === requestedSource);
++    if (picked.length) out = picked;
++  }
++  if (!specific && out.length) {
++    out[0] = { ...out[0], Id: normalizedItemId, ETag: normalizedItemId };
++  }
++  if (!out.length) {
++    const reason = errors
++      .map((e) => [e.title, e.description].filter(Boolean).join(': '))
++      .join('; ');
++    logger.warn(
++      { itemId, type: target.type, videoId: target.videoId, reason },
++      'no playable sources'
++    );
++    res.json({
++      MediaSources: [],
++      PlaySessionId: `${ctx.userId}-${Date.now()}`,
++      ErrorCode: 'NoCompatibleStream',
++    });
++    return;
++  }
++  res.json({
++    MediaSources: out,
++    PlaySessionId: `${ctx.userId}-${Date.now().toString(36)}`,
++  });
++}
++
++router.get('/Items/:itemId/PlaybackInfo', jf(playbackInfo));
++router.post('/Items/:itemId/PlaybackInfo', jf(playbackInfo));
++
++router.get(
++  '/Items/:itemId/MediaSources',
++  jf(async (req, res, ctx) => {
++    await playbackInfo(req, res, ctx);
++  })
++);
++
++interface StreamTarget {
++  url: string;
++  headers?: Record<string, string>;
++  responseHeaders?: Record<string, string>;
++  filename?: string;
++}
++
++async function resolveStreamTarget(
++  req: Request,
++  ctx: JellyfinRequestContext,
++  d: JellyfinItemDescriptor
++): Promise<StreamTarget | null> {
++  const t = qs(req, 't');
++  if (t) {
++    const plain = decrypt(t);
++    if (plain) {
++      try {
++        const parsed = JSON.parse(plain) as {
++          u: string;
++          h?: Record<string, string>;
++          r?: Record<string, string>;
++          f?: string;
++        };
++        if (parsed.u)
++          return {
++            url: parsed.u,
++            headers: parsed.h,
++            responseHeaders: parsed.r,
++            filename: parsed.f,
++          };
++      } catch {}
++    }
++  }
++  const target = await playTarget(ctx, d);
++  if (!target) return null;
++  const rawMsid = qs(req, 'MediaSourceId');
++  const itemGuid = param(req, 'itemId').replace(/-/g, '').toLowerCase();
++  const msid =
++    rawMsid && rawMsid.replace(/-/g, '').toLowerCase() === itemGuid
++      ? undefined
++      : rawMsid;
++  const playable = await ctx.service.resolvePlayable(
++    target.type,
++    target.videoId
++  );
++  if (!playable.length) return null;
++  const pick: PlayableStreamRecord | undefined = msid
++    ? playable.find((p) => p.msid === msid)
++    : playable[0];
++  const chosen = pick ?? playable[0];
++  return {
++    url: chosen.url,
++    headers: chosen.headers,
++    responseHeaders: chosen.responseHeaders,
++    filename: chosen.filename,
++  };
++}
++
++async function streamHandler(
++  req: Request,
++  res: Response,
++  ctx: JellyfinRequestContext
++) {
++  const d = await decodeJellyfinId(param(req, 'itemId'));
++  if (!d) {
++    res.status(404).json({ Message: 'Item not found' });
++    return;
++  }
++  const target = await resolveStreamTarget(req, ctx, d);
++  if (!target) {
++    res.status(404).json({ Message: 'No playable stream' });
++    return;
++  }
++  res.redirect(302, target.url);
++}
++
++router.get(
++  [
++    '/Videos/:itemId/stream',
++    '/Videos/:itemId/stream.:ext',
++    '/Videos/:itemId/stream/:filename',
++    '/Videos/:itemId/original',
++    '/Videos/:itemId/original.:ext',
++    '/Items/:itemId/Download',
++    '/Items/:itemId/File',
++  ],
++  jf(streamHandler)
++);
++router.head(
++  [
++    '/Videos/:itemId/stream',
++    '/Videos/:itemId/stream.:ext',
++    '/Videos/:itemId/stream/:filename',
++    '/Items/:itemId/Download',
++  ],
++  jf(streamHandler)
++);
++
++router.get(
++  [
++    '/Videos/:itemId/master.m3u8',
++    '/Videos/:itemId/main.m3u8',
++    '/Videos/:itemId/live.m3u8',
++    '/Videos/:itemId/hls1/{*rest}',
++    '/Videos/:itemId/hls/{*rest}',
++  ],
++  jf(async (_req, res) => {
++    res.status(501).json({
++      Message: 'Transcoding is not supported by this server; use direct play.',
++    });
++  })
++);
++router.delete('/Videos/ActiveEncodings', (_req, res) => {
++  res.status(204).end();
++});
++
++router.get(
++  [
++    '/Videos/:itemId/:mediaSourceId/Subtitles/:index/Stream.:format',
++    '/Videos/:itemId/:mediaSourceId/Subtitles/:index/:start/Stream.:format',
++  ],
++  jf(async (req, res, ctx) => {
++    const u = qs(req, 'u');
++    let url = u ? decrypt(u) : null;
++    if (!url) {
++      const d = await decodeJellyfinId(param(req, 'itemId'));
++      const target = d ? await playTarget(ctx, d) : null;
++      if (target) {
++        const playable = await ctx.service.resolvePlayable(
++          target.type,
++          target.videoId
++        );
++        const rec = playable.find(
++          (p) => p.msid === param(req, 'mediaSourceId')
++        );
++        const idx = Number(param(req, 'index'));
++        const subs = [
++          ...(rec?.subtitles ?? []),
++          ...(await ctx.service.getSubtitles(target.type, target.videoId)),
++        ];
++        url = subs[idx]?.url ?? null;
++      }
++    }
++    if (!url) {
++      res.status(404).end();
++      return;
++    }
++    try {
++      const upstream = await relay(url);
++      if (!upstream.ok || !upstream.body) {
++        res.status(upstream.status >= 400 ? upstream.status : 502).end();
++        return;
++      }
++      res.status(200);
++      res.setHeader(
++        'content-type',
++        upstream.headers.get('content-type') ?? 'text/plain; charset=utf-8'
++      );
++      await pipeline(
++        Readable.fromWeb(upstream.body as import('stream/web').ReadableStream),
++        res
++      ).catch(() => undefined);
++    } catch (error) {
++      logger.debug(
++        { err: error instanceof Error ? error.message : String(error) },
++        'subtitle relay failed'
++      );
++      if (!res.headersSent) res.status(502).end();
++    }
++  })
++);
++
++const FALLBACK_IMAGE = '/logo.png';
++
++function metahubImageUrl(
++  d: JellyfinItemDescriptor,
++  want: string
++): string | null {
++  if (!('i' in d) || typeof d.i !== 'string' || !d.i.startsWith('tt'))
++    return null;
++  if (d.k === 'episode')
++    return `https://images.metahub.space/background/medium/${d.i}/img`;
++  if (d.k !== 'movie' && d.k !== 'series' && d.k !== 'season') return null;
++  if (want === 'primary' || want === 'thumb')
++    return `https://images.metahub.space/poster/medium/${d.i}/img`;
++  if (want === 'backdrop' || want === 'art' || want === 'banner')
++    return `https://images.metahub.space/background/medium/${d.i}/img`;
++  if (want === 'logo')
++    return `https://images.metahub.space/logo/medium/${d.i}/img`;
++  return null;
++}
++
++interface ResolvedImage {
++  url: string;
++  public: boolean;
++}
++
++const ARTWORK_KINDS = new Set(['movie', 'series', 'season', 'episode']);
++
++const inflightRebuilds = new Map<
++  string,
++  Promise<RememberedImages | undefined>
++>();
++
++async function rebuildImages(
++  uuid: string | undefined,
++  getCtx: () => Promise<JellyfinRequestContext | null>,
++  d: JellyfinItemDescriptor,
++  id: string
++): Promise<RememberedImages | undefined> {
++  const run = async (): Promise<RememberedImages | undefined> => {
++    const ctx = await getCtx().catch(() => null);
++    if (!ctx) return undefined;
++    const { itemFromDescriptor } = await import('./items.js');
++    const ran = await itemFromDescriptor(ctx, d).then(
++      () => true,
++      () => false
++    );
++    const found = await recallImages(ctx.uuid, id);
++    if (found?.complete) return found;
++    if (!ran) return found;
++    const settled = { images: found?.images ?? {}, complete: true };
++    rememberImages(ctx.uuid, id, settled.images, true);
++    return settled;
++  };
++  if (!uuid) return run();
++  const cacheKey = `${uuid}|${id}`;
++  let inFlight = inflightRebuilds.get(cacheKey);
++  if (!inFlight) {
++    inFlight = run().finally(() => inflightRebuilds.delete(cacheKey));
++    inflightRebuilds.set(cacheKey, inFlight);
++  }
++  return inFlight;
++}
++
++async function imageUrlFor(
++  uuid: string | undefined,
++  getCtx: () => Promise<JellyfinRequestContext | null>,
++  itemId: string,
++  type: string,
++  opts: { rebuild?: boolean } = {}
++): Promise<ResolvedImage | null> {
++  const id = itemId.replace(/-/g, '').toLowerCase();
++  const want = type.toLowerCase();
++  const pick = (imgs: ItemImages | undefined) => {
++    if (!imgs) return null;
++    switch (want) {
++      case 'primary':
++        return imgs.Primary ?? imgs.Thumb ?? imgs.Backdrop ?? null;
++      case 'backdrop':
++      case 'art':
++      case 'banner':
++        return imgs.Backdrop ?? imgs.Primary ?? null;
++      case 'thumb':
++        return imgs.Thumb ?? imgs.Backdrop ?? imgs.Primary ?? null;
++      case 'logo':
++        return imgs.Logo ?? null;
++      default:
++        return imgs.Primary ?? null;
++    }
++  };
++  const remembered = uuid ? await recallImages(uuid, id) : undefined;
++  const cached = pick(remembered?.images);
++  if (cached) return { url: cached, public: false };
++  const d = await decodeJellyfinId(id);
++  if (!d) return null;
++  if (!ARTWORK_KINDS.has(d.k)) return null;
++  if (opts.rebuild !== false && !remembered?.complete) {
++    const rebuilt = pick((await rebuildImages(uuid, getCtx, d, id))?.images);
++    if (rebuilt) return { url: rebuilt, public: false };
++  }
++  const fallback = metahubImageUrl(d, want);
++  return fallback ? { url: fallback, public: true } : null;
++}
++
++function lazyCtx(req: Request): () => Promise<JellyfinRequestContext | null> {
++  return () =>
++    req.jf
++      ? Promise.resolve(req.jf)
++      : (req.jfLazy?.() ?? Promise.resolve(null));
++}
++
++router.get(
++  ['/Items/:itemId/Images/:type', '/Items/:itemId/Images/:type/:index'],
++  async (req, res) => {
++    const result = await imageUrlFor(
++      req.uuid,
++      lazyCtx(req),
++      param(req, 'itemId'),
++      param(req, 'type')
++    ).catch(() => null);
++    if (!result) {
++      res.status(404).end();
++      return;
++    }
++    try {
++      const headers: Record<string, string> = {};
++      const inm = req.headers['if-none-match'];
++      if (typeof inm === 'string') headers['if-none-match'] = inm;
++      const ims = req.headers['if-modified-since'];
++      if (typeof ims === 'string') headers['if-modified-since'] = ims;
++      const upstream = await relay(result.url, headers);
++      res.status(upstream.status);
++      for (const h of [
++        'content-type',
++        'content-length',
++        'etag',
++        'last-modified',
++        'cache-control',
++        'expires',
++      ]) {
++        const v = upstream.headers.get(h);
++        if (v) res.setHeader(h, v);
++      }
++      if (!upstream.body || upstream.status === 304) {
++        res.end();
++        return;
++      }
++      await pipeline(
++        Readable.fromWeb(upstream.body as import('stream/web').ReadableStream),
++        res
++      ).catch(() => undefined);
++    } catch (error) {
++      logger.debug(
++        { err: error instanceof Error ? error.message : String(error) },
++        'image relay failed'
++      );
++      if (res.headersSent) return;
++      if (result.public) res.redirect(302, result.url);
++      else res.status(502).end();
++    }
++  }
++);
++router.head(
++  ['/Items/:itemId/Images/:type', '/Items/:itemId/Images/:type/:index'],
++  async (req, res) => {
++    const result = await imageUrlFor(
++      req.uuid,
++      lazyCtx(req),
++      param(req, 'itemId'),
++      param(req, 'type'),
++      { rebuild: false }
++    ).catch(() => null);
++    if (!result) {
++      res.status(404).end();
++      return;
++    }
++    res.status(200).end();
++  }
++);
++router.get(
++  '/Items/:itemId/Images',
++  jf(async (req, res, ctx) => {
++    const id = param(req, 'itemId').replace(/-/g, '').toLowerCase();
++    const imgs = (await recallImages(ctx.uuid, id))?.images ?? {};
++    const out = Object.entries(imgs)
++      .filter(([, v]) => !!v)
++      .map(([k]) => ({
++        ImageType: k,
++        ImageIndex: k === 'Backdrop' ? 0 : undefined,
++        Path: '',
++        Size: 0,
++        Width: 0,
++        Height: 0,
++      }));
++    res.json(out);
++  })
++);
++router.get(
++  [
++    '/Users/:userId/Images/:type',
++    '/Users/:userId/Images/:type/:index',
++    '/UserImage',
++  ],
++  (_req, res) => {
++    res.redirect(302, FALLBACK_IMAGE);
++  }
++);
++router.get(['/Branding/Splashscreen'], (_req, res) => {
++  res.redirect(302, FALLBACK_IMAGE);
++});
++router.get('/Images/General/:name/:type', (_req, res) => {
++  res.redirect(302, FALLBACK_IMAGE);
++});
++
++function ticksFrom(
++  body: Record<string, unknown>,
++  req: Request,
++  key: string
++): number | undefined {
++  const v =
++    body[key] ??
++    body[key.charAt(0).toLowerCase() + key.slice(1)] ??
++    qs(req, key);
++  if (v == null || v === '') return undefined;
++  const n = Number(v);
++  return Number.isFinite(n) ? n : undefined;
++}
++
++function idFrom(
++  body: Record<string, unknown>,
++  req: Request
++): string | undefined {
++  const v =
++    body.ItemId ?? body.itemId ?? qs(req, 'ItemId') ?? param(req, 'itemId');
++  return typeof v === 'string' && v
++    ? v.replace(/-/g, '').toLowerCase()
++    : undefined;
++}
++
++const PLAYED_THRESHOLD = 0.9;
++
++const PROGRESS_MIN_DELTA_TICKS = 30 * 10_000_000;
++const PROGRESS_MIN_WALL_MS = 60_000;
++const lastProgressWrite = new Map<string, { pos: number; at: number }>();
++const LAST_PROGRESS_MAX = 20_000;
++
++async function recordProgress(
++  ctx: JellyfinRequestContext,
++  itemId: string,
++  positionTicks: number | undefined,
++  event: 'start' | 'progress' | 'stop'
++) {
++  const d = await decodeJellyfinId(itemId);
++  if (!d || (d.k !== 'movie' && d.k !== 'episode')) return;
++  const throttleKey = `${ctx.uuid}:${itemId}`;
++  if (event === 'progress' && positionTicks != null) {
++    const last = lastProgressWrite.get(throttleKey);
++    if (
++      last &&
++      Math.abs(positionTicks - last.pos) < PROGRESS_MIN_DELTA_TICKS &&
++      Date.now() - last.at < PROGRESS_MIN_WALL_MS
++    ) {
++      return;
++    }
++  }
++  if (lastProgressWrite.size >= LAST_PROGRESS_MAX) lastProgressWrite.clear();
++  lastProgressWrite.set(throttleKey, {
++    pos: positionTicks ?? 0,
++    at: Date.now(),
++  });
++  const runtimeTicks = (await runtimeTicksFor(ctx, d)) ?? 0;
++  const existing = await JellyfinRepository.getPlaystate(ctx.uuid, itemId);
++  const rt = runtimeTicks || existing?.runtimeTicks || 0;
++  const pos = positionTicks ?? existing?.positionTicks ?? 0;
++  const now = Date.now();
++  if (event === 'start') {
++    await JellyfinRepository.upsertPlaystate(ctx.uuid, itemId, d, {
++      runtimeTicks: rt || undefined,
++      positionTicks: positionTicks ?? undefined,
++      lastPlayedAt: now,
++    });
++    return;
++  }
++  const finished = rt > 0 && pos >= rt * PLAYED_THRESHOLD;
++  if (finished) {
++    await JellyfinRepository.upsertPlaystate(ctx.uuid, itemId, d, {
++      positionTicks: 0,
++      runtimeTicks: rt || undefined,
++      played: true,
++      incrementPlayCount: event === 'stop' ? 'if-unplayed' : false,
++      lastPlayedAt: now,
++    });
++    return;
++  }
++  await JellyfinRepository.upsertPlaystate(ctx.uuid, itemId, d, {
++    positionTicks: pos,
++    runtimeTicks: rt || undefined,
++    played: false,
++    lastPlayedAt: now,
++  });
++}
++
++router.post(
++  ['/Sessions/Playing', '/PlayingItems/:itemId'],
++  jf(async (req, res, ctx) => {
++    const body = (req.body ?? {}) as Record<string, unknown>;
++    const id = idFrom(body, req);
++    if (id)
++      await recordProgress(
++        ctx,
++        id,
++        ticksFrom(body, req, 'PositionTicks'),
++        'start'
++      );
++    res.status(204).end();
++  })
++);
++router.post(
++  ['/Sessions/Playing/Progress', '/PlayingItems/:itemId/Progress'],
++  jf(async (req, res, ctx) => {
++    const body = (req.body ?? {}) as Record<string, unknown>;
++    const id = idFrom(body, req);
++    if (id)
++      await recordProgress(
++        ctx,
++        id,
++        ticksFrom(body, req, 'PositionTicks'),
++        'progress'
++      );
++    res.status(204).end();
++  })
++);
++router.post(
++  ['/Sessions/Playing/Stopped'],
++  jf(async (req, res, ctx) => {
++    const body = (req.body ?? {}) as Record<string, unknown>;
++    const id = idFrom(body, req);
++    if (id)
++      await recordProgress(
++        ctx,
++        id,
++        ticksFrom(body, req, 'PositionTicks'),
++        'stop'
++      );
++    res.status(204).end();
++  })
++);
++router.delete(
++  '/PlayingItems/:itemId',
++  jf(async (req, res, ctx) => {
++    const id = idFrom({}, req);
++    if (id)
++      await recordProgress(
++        ctx,
++        id,
++        ticksFrom({}, req, 'PositionTicks'),
++        'stop'
++      );
++    res.status(204).end();
++  })
++);
++router.post('/Sessions/Playing/Ping', (_req, res) => {
++  res.status(204).end();
++});
++
++async function userDataResponse(ctx: JellyfinRequestContext, itemId: string) {
++  const d = await decodeJellyfinId(itemId);
++  if (!d) return null;
++  const { itemFromDescriptor } = await import('./items.js');
++  const row = await JellyfinRepository.getPlaystate(ctx.uuid, itemId);
++  const item = await itemFromDescriptor(ctx, d, {
++    playstate: row ?? undefined,
++  });
++  return item?.UserData ?? null;
++}
++
++router.post(
++  ['/Users/:userId/PlayedItems/:itemId', '/UserPlayedItems/:itemId'],
++  jf(async (req, res, ctx) => {
++    const id = param(req, 'itemId').replace(/-/g, '').toLowerCase();
++    const d = await decodeJellyfinId(id);
++    if (!d) {
++      res.status(404).json({ Message: 'Item not found' });
++      return;
++    }
++    if (d.k === 'series' || d.k === 'season') {
++      const { episodesForSeries } = await import('./items.js');
++      const r = await episodesForSeries(
++        ctx,
++        d,
++        d.k === 'season' ? d.s : undefined
++      );
++      for (const ep of r?.episodes ?? []) {
++        const epDesc = (ep as { _aio?: { descriptor: JellyfinItemDescriptor } })
++          ._aio?.descriptor;
++        if (!epDesc) continue;
++        await JellyfinRepository.upsertPlaystate(ctx.uuid, ep.Id, epDesc, {
++          played: true,
++          positionTicks: 0,
++          incrementPlayCount: true,
++          lastPlayedAt: Date.now(),
++        });
++      }
++    } else {
++      await JellyfinRepository.upsertPlaystate(ctx.uuid, id, d, {
++        played: true,
++        positionTicks: 0,
++        incrementPlayCount: true,
++        lastPlayedAt: Date.now(),
++      });
++    }
++    res.json((await userDataResponse(ctx, id)) ?? { Played: true });
++  })
++);
++router.delete(
++  ['/Users/:userId/PlayedItems/:itemId', '/UserPlayedItems/:itemId'],
++  jf(async (req, res, ctx) => {
++    const id = param(req, 'itemId').replace(/-/g, '').toLowerCase();
++    const d = await decodeJellyfinId(id);
++    if (!d) {
++      res.status(404).json({ Message: 'Item not found' });
++      return;
++    }
++    if (d.k === 'series' || d.k === 'season') {
++      const { episodesForSeries } = await import('./items.js');
++      const r = await episodesForSeries(
++        ctx,
++        d,
++        d.k === 'season' ? d.s : undefined
++      );
++      for (const ep of r?.episodes ?? []) {
++        const epDesc = (ep as { _aio?: { descriptor: JellyfinItemDescriptor } })
++          ._aio?.descriptor;
++        if (!epDesc) continue;
++        await JellyfinRepository.upsertPlaystate(ctx.uuid, ep.Id, epDesc, {
++          played: false,
++          positionTicks: 0,
++        });
++      }
++    } else {
++      await JellyfinRepository.upsertPlaystate(ctx.uuid, id, d, {
++        played: false,
++        positionTicks: 0,
++      });
++    }
++    res.json((await userDataResponse(ctx, id)) ?? { Played: false });
++  })
++);
++
++router.post(
++  ['/UserItems/:itemId/UserData', '/Users/:userId/Items/:itemId/UserData'],
++  jf(async (req, res, ctx) => {
++    const id = param(req, 'itemId').replace(/-/g, '').toLowerCase();
++    const d = await decodeJellyfinId(id);
++    if (!d) {
++      res.status(404).json({ Message: 'Item not found' });
++      return;
++    }
++    const body = (req.body ?? {}) as Record<string, unknown>;
++    await JellyfinRepository.upsertPlaystate(ctx.uuid, id, d, {
++      played: typeof body.Played === 'boolean' ? body.Played : undefined,
++      favorite:
++        typeof body.IsFavorite === 'boolean' ? body.IsFavorite : undefined,
++      positionTicks:
++        typeof body.PlaybackPositionTicks === 'number'
++          ? body.PlaybackPositionTicks
++          : undefined,
++    });
++    res.json((await userDataResponse(ctx, id)) ?? {});
++  })
++);
++router.get(
++  ['/UserItems/:itemId/UserData', '/Users/:userId/Items/:itemId/UserData'],
++  jf(async (req, res, ctx) => {
++    const id = param(req, 'itemId').replace(/-/g, '').toLowerCase();
++    res.json((await userDataResponse(ctx, id)) ?? {});
++  })
++);
++
++export default router;
+diff --git a/packages/server/src/routes/jellyfin/relay-target.test.ts b/packages/server/src/routes/jellyfin/relay-target.test.ts
+new file mode 100644
+index 00000000..831f8cbb
+--- /dev/null
++++ b/packages/server/src/routes/jellyfin/relay-target.test.ts
+@@ -0,0 +1,63 @@
++import { describe, it, expect } from 'vitest';
++import { isRelayLoop } from './relay-target.js';
++
++const SELF = new Set(['https://aio.example.com', 'http://localhost:3000']);
++
++describe('isRelayLoop', () => {
++  it('rejects a target pointing back at this server’s own image relay', () => {
++    expect(
++      isRelayLoop(
++        'https://aio.example.com/jellyfin/Items/abc123/Images/Primary',
++        SELF
++      )
++    ).toBe(true);
++    expect(
++      isRelayLoop(
++        'https://aio.example.com/jellyfin/uuid/pwd/Items/abc/Images/Backdrop/0',
++        SELF
++      )
++    ).toBe(true);
++    expect(
++      isRelayLoop('http://localhost:3000/jellyfin/Items/x/Images/Logo', SELF)
++    ).toBe(true);
++  });
++
++  it('rejects a target pointing back at the subtitle relay', () => {
++    expect(
++      isRelayLoop(
++        'https://aio.example.com/jellyfin/Videos/item1/ms1/Subtitles/0/0/Stream.srt',
++        SELF
++      )
++    ).toBe(true);
++  });
++
++  it('allows other routes on this same origin', () => {
++    expect(
++      isRelayLoop('https://aio.example.com/builtins/gdrive/poster.jpg', SELF)
++    ).toBe(false);
++    expect(isRelayLoop('https://aio.example.com/logo.png', SELF)).toBe(false);
++    expect(
++      isRelayLoop('https://aio.example.com/api/v1/posters/abc.jpg', SELF)
++    ).toBe(false);
++  });
++
++  it('allows relay-shaped paths on somebody else’s origin', () => {
++    expect(
++      isRelayLoop(
++        'https://images.metahub.space/poster/medium/tt0111161/img',
++        SELF
++      )
++    ).toBe(false);
++    expect(
++      isRelayLoop(
++        'https://other.example.com/jellyfin/Items/abc/Images/Primary',
++        SELF
++      )
++    ).toBe(false);
++  });
++
++  it('treats an unparseable target as not-a-loop, leaving it to the fetch', () => {
++    expect(isRelayLoop('not a url', SELF)).toBe(false);
++    expect(isRelayLoop('', SELF)).toBe(false);
++  });
++});
+diff --git a/packages/server/src/routes/jellyfin/relay-target.ts b/packages/server/src/routes/jellyfin/relay-target.ts
+new file mode 100644
+index 00000000..974e904f
+--- /dev/null
++++ b/packages/server/src/routes/jellyfin/relay-target.ts
+@@ -0,0 +1,16 @@
++const RELAY_ROUTE =
++  /\/(Items\/[^/]+\/Images|Videos\/[^/]+\/[^/]+\/Subtitles)(\/|$)/i;
++
++export function isRelayLoop(
++  url: string,
++  selfOrigins: ReadonlySet<string>
++): boolean {
++  let parsed: URL;
++  try {
++    parsed = new URL(url);
++  } catch {
++    return false;
++  }
++  if (!selfOrigins.has(parsed.origin)) return false;
++  return RELAY_ROUTE.test(parsed.pathname);
++}
+diff --git a/packages/server/src/routes/jellyfin/system.ts b/packages/server/src/routes/jellyfin/system.ts
+new file mode 100644
+index 00000000..96e9841a
+--- /dev/null
++++ b/packages/server/src/routes/jellyfin/system.ts
+@@ -0,0 +1,644 @@
++import { Router, type Request, type Response } from 'express';
++import {
++  config as appConfig,
++  createLogger,
++  encryptString,
++  isConfigUuid,
++  resolveConfigAlias,
++  UserRepository,
++  uuidToJellyfinUserId,
++  JellyfinRepository,
++} from '@aiostreams/core';
++import {
++  JELLYFIN_PRODUCT_NAME,
++  JELLYFIN_SERVER_VERSION,
++  jf,
++  mintToken,
++  parseMediaBrowserHeader,
++  requestOrigin,
++  resolveUserData,
++  serverIdFor,
++  type JellyfinRequestContext,
++  param,
++} from './context.js';
++
++const logger = createLogger('jellyfin');
++const router: Router = Router({ mergeParams: true });
++
++const serverName = () => appConfig.branding.addonName || 'AIOStreams';
++
++function publicInfo(req: Request) {
++  const ctx = req.jf;
++  return {
++    LocalAddress: `${requestOrigin(req)}${req.baseUrl}`,
++    ServerName: ctx?.userData.addonName || serverName(),
++    Version: JELLYFIN_SERVER_VERSION,
++    ProductName: JELLYFIN_PRODUCT_NAME,
++    OperatingSystem: 'Linux',
++    Id: ctx?.serverId ?? 'aiostreams00000000000000000000000',
++    StartupWizardCompleted: true,
++  };
++}
++
++router.get('/System/Info/Public', (req, res) => {
++  res.json(publicInfo(req));
++});
++
++router.get(
++  '/System/Info',
++  jf(async (req, res, ctx) => {
++    res.json({
++      ...publicInfo(req),
++      SystemArchitecture: 'X64',
++      OperatingSystemDisplayName: 'Linux',
++      HasPendingRestart: false,
++      IsShuttingDown: false,
++      SupportsLibraryMonitor: false,
++      WebSocketPortNumber: appConfig.bootstrap.port,
++      CompletedInstallations: [],
++      CanSelfRestart: false,
++      CanLaunchWebBrowser: false,
++      ProgramDataPath: '/config',
++      WebPath: '/web',
++      ItemsByNamePath: '/config/metadata',
++      CachePath: '/cache',
++      LogPath: '/config/log',
++      InternalMetadataPath: '/config/metadata',
++      TranscodingTempPath: '/cache/transcodes',
++      HasUpdateAvailable: false,
++      EncoderLocation: 'NotFound',
++      PackageName: 'aiostreams',
++      LocalAddress: `${requestOrigin(req)}${req.baseUrl}`,
++      ServerName: ctx.userData.addonName || serverName(),
++    });
++  })
++);
++
++router.all('/System/Ping', (_req, res) => {
++  res.json(JELLYFIN_PRODUCT_NAME);
++});
++
++router.get('/System/Endpoint', (req, res) => {
++  res.json({ IsLocal: false, IsInNetwork: false });
++});
++
++router.get(
++  '/System/Configuration',
++  jf(async (_req, res) => {
++    res.json({
++      EnableMetrics: false,
++      ServerName: serverName(),
++      PreferredMetadataLanguage: 'en',
++      MetadataCountryCode: 'US',
++      EnableCaseSensitiveItemIds: true,
++      EnableFolderView: false,
++      EnableGroupingIntoCollections: false,
++      DisplaySpecialsWithinSeasons: true,
++      UICulture: 'en-US',
++      SaveMetadataHidden: false,
++      ContentTypes: [],
++      RemoteClientBitrateLimit: 0,
++      EnableSlowResponseWarning: false,
++      LibraryScanFanoutConcurrency: 0,
++      LibraryMetadataRefreshConcurrency: 0,
++      PluginRepositories: [],
++      CorsHosts: ['*'],
++      IsStartupWizardCompleted: true,
++    });
++  })
++);
++
++router.get('/Branding/Configuration', (_req, res) => {
++  res.json({
++    LoginDisclaimer: `Sign in with your ${serverName()} config UUID and password.`,
++    CustomCss: '',
++    SplashscreenEnabled: false,
++  });
++});
++router.get(['/Branding/Css', '/Branding/Css.css'], (_req, res) => {
++  res.type('text/css').send('');
++});
++router.get('/Branding/Splashscreen', (_req, res) => {
++  res.redirect(302, '/logo.png');
++});
++
++function userDto(
++  ctx: Pick<JellyfinRequestContext, 'uuid' | 'userData' | 'serverId'>
++) {
++  const userId = uuidToJellyfinUserId(ctx.uuid);
++  return {
++    Name: ctx.userData.addonName || serverName(),
++    ServerId: ctx.serverId,
++    Id: userId,
++    HasPassword: true,
++    HasConfiguredPassword: true,
++    HasConfiguredEasyPassword: false,
++    EnableAutoLogin: true,
++    LastLoginDate: new Date().toISOString(),
++    LastActivityDate: new Date().toISOString(),
++    Configuration: userConfiguration(),
++    Policy: userPolicy(),
++  };
++}
++
++function userConfiguration() {
++  return {
++    PlayDefaultAudioTrack: true,
++    SubtitleLanguagePreference: '',
++    DisplayMissingEpisodes: false,
++    GroupedFolders: [],
++    SubtitleMode: 'Default',
++    DisplayCollectionsView: false,
++    EnableLocalPassword: false,
++    OrderedViews: [],
++    LatestItemsExcludes: [],
++    MyMediaExcludes: [],
++    HidePlayedInLatest: true,
++    RememberAudioSelections: true,
++    RememberSubtitleSelections: true,
++    EnableNextEpisodeAutoPlay: true,
++    CastReceiverId: '',
++  };
++}
++
++function userPolicy() {
++  return {
++    IsAdministrator: false,
++    IsHidden: false,
++    EnableCollectionManagement: false,
++    EnableSubtitleManagement: false,
++    EnableLyricManagement: false,
++    IsDisabled: false,
++    BlockedTags: [],
++    AllowedTags: [],
++    EnableUserPreferenceAccess: true,
++    AccessSchedules: [],
++    BlockUnratedItems: [],
++    EnableRemoteControlOfOtherUsers: false,
++    EnableSharedDeviceControl: false,
++    EnableRemoteAccess: true,
++    EnableLiveTvManagement: false,
++    EnableLiveTvAccess: false,
++    EnableMediaPlayback: true,
++    EnableAudioPlaybackTranscoding: false,
++    EnableVideoPlaybackTranscoding: false,
++    EnablePlaybackRemuxing: false,
++    ForceRemoteSourceTranscoding: false,
++    EnableContentDeletion: false,
++    EnableContentDeletionFromFolders: [],
++    EnableContentDownloading: true,
++    EnableSyncTranscoding: false,
++    EnableMediaConversion: false,
++    EnabledDevices: [],
++    EnableAllDevices: true,
++    EnabledChannels: [],
++    EnableAllChannels: true,
++    EnabledFolders: [],
++    EnableAllFolders: true,
++    InvalidLoginAttemptCount: 0,
++    LoginAttemptsBeforeLockout: -1,
++    MaxActiveSessions: 0,
++    EnablePublicSharing: false,
++    BlockedMediaFolders: [],
++    BlockedChannels: [],
++    RemoteClientBitrateLimit: 0,
++    AuthenticationProviderId:
++      'Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider',
++    PasswordResetProviderId:
++      'Jellyfin.Server.Implementations.Users.DefaultPasswordResetProvider',
++    SyncPlayAccess: 'None',
++  };
++}
++
++function sessionInfo(ctx: JellyfinRequestContext, req: Request) {
++  const mb = parseMediaBrowserHeader(
++    req.get('authorization') ?? req.get('x-emby-authorization')
++  );
++  return {
++    PlayState: {
++      CanSeek: true,
++      IsPaused: false,
++      IsMuted: false,
++      RepeatMode: 'RepeatNone',
++      PlaybackOrder: 'Default',
++    },
++    AdditionalUsers: [],
++    Capabilities: {
++      PlayableMediaTypes: ['Video'],
++      SupportedCommands: [],
++      SupportsMediaControl: false,
++      SupportsPersistentIdentifier: false,
++    },
++    RemoteEndPoint: req.userIp ?? '',
++    PlayableMediaTypes: ['Video'],
++    Id: `${ctx.userId}-${mb.deviceid ?? 'device'}`,
++    UserId: ctx.userId,
++    UserName: ctx.userData.addonName || serverName(),
++    Client: mb.client ?? 'Unknown',
++    LastActivityDate: new Date().toISOString(),
++    LastPlaybackCheckIn: new Date(0).toISOString(),
++    DeviceName: mb.device ?? 'Unknown',
++    DeviceId: mb.deviceid ?? 'unknown',
++    ApplicationVersion: mb.version ?? '0',
++    IsActive: true,
++    SupportsMediaControl: false,
++    SupportsRemoteControl: false,
++    NowPlayingQueue: [],
++    NowPlayingQueueFullItems: [],
++    HasCustomDeviceName: false,
++    ServerId: ctx.serverId,
++    SupportedCommands: [],
++  };
++}
++
++router.get('/Users/Public', (req, res) => {
++  if (req.jf?.preAuthenticated) {
++    res.json([userDto(req.jf)]);
++    return;
++  }
++  res.json([]);
++});
++
++router.post('/Users/AuthenticateByName', async (req, res) => {
++  try {
++    const body = (req.body ?? {}) as Record<string, unknown>;
++    const username = String(body.Username ?? body.username ?? '').trim();
++    const pw = String(
++      body.Pw ?? body.pw ?? body.Password ?? body.password ?? ''
++    );
++    const mb = parseMediaBrowserHeader(
++      req.get('authorization') ?? req.get('x-emby-authorization')
++    );
++
++    let uuid: string | undefined;
++    let encryptedPassword: string | undefined;
++
++    if (req.jf?.preAuthenticated) {
++      uuid = req.jf.uuid;
++      encryptedPassword = req.jf.encryptedPassword;
++    } else {
++      if (!username) {
++        res
++          .status(401)
++          .json({ Message: 'Username (config UUID or alias) is required' });
++        return;
++      }
++      let candidate = username;
++      if (!isConfigUuid(candidate)) {
++        const alias = await resolveConfigAlias(candidate);
++        if (!alias) {
++          res.status(401).json({ Message: 'Unknown user' });
++          return;
++        }
++        candidate = alias.uuid;
++        uuid = candidate;
++        encryptedPassword = alias.encryptedPassword;
++      } else {
++        const enc = encryptString(pw);
++        if (!enc.success || !enc.data) {
++          res.status(500).json({ Message: 'Encryption failure' });
++          return;
++        }
++        uuid = candidate;
++        encryptedPassword = enc.data;
++      }
++    }
++
++    const resolved = await resolveUserData(
++      uuid!,
++      encryptedPassword!,
++      req.userIp
++    );
++    if (!resolved) {
++      res.status(401).json({ Message: 'Invalid username or password' });
++      return;
++    }
++    const token = mintToken({
++      u: resolved.uuid,
++      p: encryptedPassword!,
++      d: mb.deviceid,
++    });
++    const ctx = {
++      uuid: resolved.uuid,
++      userData: resolved.userData,
++      serverId: serverIdFor(resolved.uuid),
++      userId: uuidToJellyfinUserId(resolved.uuid),
++    } as JellyfinRequestContext;
++    logger.info(
++      { uuid: resolved.uuid, client: mb.client, device: mb.device },
++      'jellyfin client authenticated'
++    );
++    res.json({
++      User: userDto(ctx),
++      SessionInfo: sessionInfo(ctx, req),
++      AccessToken: token,
++      ServerId: ctx.serverId,
++    });
++  } catch (error) {
++    logger.error(
++      `authenticate failed: ${error instanceof Error ? error.message : error}`
++    );
++    res.status(500).json({ Message: 'Authentication failed' });
++  }
++});
++
++router.post('/Users/AuthenticateWithQuickConnect', (_req, res) => {
++  res.status(401).json({ Message: 'Quick Connect is not available' });
++});
++router.get('/QuickConnect/Enabled', (_req, res) => {
++  res.json(false);
++});
++router.all(
++  [
++    '/QuickConnect/Initiate',
++    '/QuickConnect/Connect',
++    '/QuickConnect/Authorize',
++  ],
++  (_req, res) => {
++    res.status(401).json({ Message: 'Quick Connect is not available' });
++  }
++);
++
++router.post('/Sessions/Logout', (_req, res) => {
++  res.status(204).end();
++});
++
++router.get(
++  '/Users/Me',
++  jf(async (_req, res, ctx) => {
++    res.json(userDto(ctx));
++  })
++);
++router.get(
++  '/Users',
++  jf(async (_req, res, ctx) => {
++    res.json([userDto(ctx)]);
++  })
++);
++router.get(
++  '/Users/:userId',
++  jf(async (_req, res, ctx) => {
++    res.json(userDto(ctx));
++  })
++);
++router.get(
++  '/Users/:userId/Configuration',
++  jf(async (_req, res) => {
++    res.json(userConfiguration());
++  })
++);
++router.post(
++  ['/Users/:userId/Configuration', '/Users/Configuration'],
++  jf(async (_req, res) => {
++    res.status(204).end();
++  })
++);
++router.post(
++  [
++    '/Users/:userId/Policy',
++    '/Users/:userId/Password',
++    '/Users/:userId/EasyPassword',
++  ],
++  jf(async (_req, res) => {
++    res.status(204).end();
++  })
++);
++
++router.get(
++  '/Sessions',
++  jf(async (req, res, ctx) => {
++    res.json([sessionInfo(ctx, req)]);
++  })
++);
++router.post(
++  ['/Sessions/Capabilities', '/Sessions/Capabilities/Full'],
++  jf(async (_req, res) => {
++    res.status(204).end();
++  })
++);
++router.post(
++  '/Sessions/Viewing',
++  jf(async (_req, res) => {
++    res.status(204).end();
++  })
++);
++router.all(
++  '/Sessions/:sessionId/{*rest}',
++  (req, _res, next) =>
++    /^playing$/i.test(String(req.params.sessionId)) ? next('route') : next(),
++  jf(async (_req, res) => {
++    res.status(204).end();
++  })
++);
++router.get(
++  '/Devices',
++  jf(async (req, res, ctx) => {
++    res.json({
++      Items: [
++        {
++          Name: ctx.client.device,
++          Id: ctx.client.deviceId,
++          LastUserName: ctx.userData.addonName || serverName(),
++          AppName: ctx.client.name,
++          AppVersion: ctx.client.version,
++          LastUserId: ctx.userId,
++          DateLastActivity: new Date().toISOString(),
++        },
++      ],
++      TotalRecordCount: 1,
++      StartIndex: 0,
++    });
++  })
++);
++router.get(
++  '/Devices/Info',
++  jf(async (_req, res, ctx) => {
++    res.json({
++      Name: ctx.client.device,
++      Id: ctx.client.deviceId,
++      AppName: ctx.client.name,
++      AppVersion: ctx.client.version,
++    });
++  })
++);
++router.get(
++  '/Devices/Options',
++  jf(async (_req, res) => {
++    res.json({ CustomName: null });
++  })
++);
++router.post(
++  '/Devices/Options',
++  jf(async (_req, res) => {
++    res.status(204).end();
++  })
++);
++
++const DEFAULT_DISPLAY_PREFS = (id: string, client: string) => ({
++  Id: id,
++  ViewType: null,
++  SortBy: 'SortName',
++  IndexBy: null,
++  RememberIndexing: false,
++  PrimaryImageHeight: 250,
++  PrimaryImageWidth: 250,
++  CustomPrefs: {},
++  ScrollDirection: 'Horizontal',
++  ShowBackdrop: true,
++  RememberSorting: false,
++  SortOrder: 'Ascending',
++  ShowSidebar: false,
++  Client: client,
++});
++
++router.get(
++  '/DisplayPreferences/:id',
++  jf(async (req, res, ctx) => {
++    const client =
++      (typeof req.query.client === 'string' ? req.query.client : 'emby') ||
++      'emby';
++    const stored = await JellyfinRepository.getDisplayPrefs(
++      ctx.uuid,
++      param(req, 'id'),
++      client
++    );
++    res.json({
++      ...DEFAULT_DISPLAY_PREFS(param(req, 'id'), client),
++      ...(stored ?? {}),
++    });
++  })
++);
++router.post(
++  '/DisplayPreferences/:id',
++  jf(async (req, res, ctx) => {
++    const client =
++      (typeof req.query.client === 'string' ? req.query.client : 'emby') ||
++      'emby';
++    const body = (
++      req.body && typeof req.body === 'object' ? req.body : {}
++    ) as Record<string, unknown>;
++    await JellyfinRepository.setDisplayPrefs(
++      ctx.uuid,
++      param(req, 'id'),
++      client,
++      body
++    );
++    res.status(204).end();
++  })
++);
++
++router.get('/Localization/Cultures', (_req, res) => {
++  res.json([
++    {
++      Name: 'English',
++      DisplayName: 'English',
++      TwoLetterISOLanguageName: 'en',
++      ThreeLetterISOLanguageName: 'eng',
++      ThreeLetterISOLanguageNames: ['eng'],
++    },
++  ]);
++});
++router.get('/Localization/Countries', (_req, res) => {
++  res.json([
++    {
++      Name: 'US',
++      DisplayName: 'United States',
++      TwoLetterISORegionName: 'US',
++      ThreeLetterISORegionName: 'USA',
++    },
++  ]);
++});
++router.get('/Localization/Options', (_req, res) => {
++  res.json([{ Name: 'English (United States)', Value: 'en-US' }]);
++});
++router.get('/Localization/ParentalRatings', (_req, res) => {
++  res.json([]);
++});
++
++for (const p of [
++  '/Plugins',
++  '/ScheduledTasks',
++  '/Packages',
++  '/Repositories',
++  '/Notifications/Types',
++  '/Notifications/Services',
++  '/System/ActivityLog/Entries',
++  '/Auth/Keys',
++  '/Auth/PasswordResetProviders',
++  '/Auth/Providers',
++  '/Environment/Drives',
++  '/Environment/NetworkShares',
++  '/Library/PhysicalPaths',
++  '/Sessions/SyncPlay/List',
++  '/SyncPlay/List',
++  '/LiveTv/Programs',
++  '/LiveTv/Recordings',
++  '/LiveTv/Timers',
++  '/LiveTv/SeriesTimers',
++  '/LiveTv/Channels',
++  '/LiveTv/Programs/Recommended',
++  '/Channels',
++  '/Playlists',
++  '/Collections',
++  '/Studios',
++  '/Artists',
++  '/Artists/AlbumArtists',
++  '/Years',
++  '/Persons',
++  '/Trailers',
++  '/Audio/Genres',
++  '/MusicGenres',
++  '/Items/Intros',
++  '/Users/:userId/Items/Intros',
++]) {
++  router.get(p, (_req, res) => {
++    if (
++      /Items|Channels|Playlists|Collections|Studios|Artists|Years|Persons|Trailers|Genres|Programs|Recordings|Timers|Intros|Entries/.test(
++        p
++      )
++    ) {
++      res.json({ Items: [], TotalRecordCount: 0, StartIndex: 0 });
++    } else {
++      res.json([]);
++    }
++  });
++}
++router.get('/LiveTv/Info', (_req, res) => {
++  res.json({ Services: [], IsEnabled: false, EnabledUsers: [] });
++});
++router.get('/LiveTv/GuideInfo', (_req, res) => {
++  res.json({
++    StartDate: new Date().toISOString(),
++    EndDate: new Date().toISOString(),
++  });
++});
++router.get('/Notifications/:userId/Summary', (_req, res) => {
++  res.json({ UnreadCount: 0, MaxUnreadNotificationLevel: 'Normal' });
++});
++router.get('/Notifications/:userId', (_req, res) => {
++  res.json({ Notifications: [], TotalRecordCount: 0 });
++});
++router.get('/Playback/BitrateTest', (req, res) => {
++  const size = Math.min(
++    Number(req.query.Size ?? req.query.size ?? 102400) || 102400,
++    10 * 1024 * 1024
++  );
++  res.type('application/octet-stream').send(Buffer.alloc(size));
++});
++router.get('/Startup/{*rest}', (_req, res) => {
++  res.json({});
++});
++router.post('/Startup/{*rest}', (_req, res) => {
++  res.status(204).end();
++});
++router.post(['/Items/:itemId/Refresh', '/Library/Refresh'], (_req, res) => {
++  res.status(204).end();
++});
++router.get('/ClientLog/Document', (_req, res) => {
++  res.status(204).end();
++});
++router.post('/ClientLog/Document', (_req, res) => {
++  res.json({ FileName: 'client.log' });
++});
++
++export default router;
+diff --git a/packages/server/src/routes/jellyfin/tasks.ts b/packages/server/src/routes/jellyfin/tasks.ts
+new file mode 100644
+index 00000000..ffad97c3
+--- /dev/null
++++ b/packages/server/src/routes/jellyfin/tasks.ts
+@@ -0,0 +1,23 @@
++import { JellyfinRepository, TaskManager } from '@aiostreams/core';
++
++const ITEM_MAX_AGE_MS = 180 * 24 * 3600 * 1000;
++const PRUNE_INTERVAL_MS = 24 * 3600 * 1000;
++
++export function registerJellyfinTasks(): void {
++  TaskManager.register({
++    id: 'prune-jellyfin-items',
++    label: 'Prune Jellyfin id mappings',
++    description:
++      'Deletes hashed Jellyfin item id mappings older than 180 days that no watch state references. Browsing re-creates them.',
++    category: 'users',
++    kind: 'scheduled',
++    intervalMs: PRUNE_INTERVAL_MS,
++    enabled: true,
++    destructive: true,
++    multiReplica: 'single',
++    run: async () => {
++      const n = await JellyfinRepository.pruneItems(ITEM_MAX_AGE_MS);
++      return { ok: true, message: `pruned ${n} jellyfin id mappings` };
++    },
++  });
++}
+diff --git a/packages/server/src/routes/jellyfin/ws.ts b/packages/server/src/routes/jellyfin/ws.ts
+new file mode 100644
+index 00000000..ada243cf
+--- /dev/null
++++ b/packages/server/src/routes/jellyfin/ws.ts
+@@ -0,0 +1,94 @@
++import type { Server as HttpServer, IncomingMessage } from 'http';
++import type { Duplex } from 'stream';
++import { WebSocketServer, type WebSocket } from 'ws';
++import { createLogger } from '@aiostreams/core';
++import { readToken, verifyCredentials } from './context.js';
++
++const logger = createLogger('jellyfin');
++
++const MAX_SOCKETS_PER_USER = 16;
++const MAX_SOCKETS_TOTAL = 50_000;
++
++const SOCKET_PATH =
++  /^\/jellyfin(?:\/([^/?]+)\/([^/?]+))?(?:\/emby)?\/socket(?:\?|$)/i;
++
++function reject(socket: Duplex, status: number, text: string) {
++  socket.write(`HTTP/1.1 ${status} ${text}\r\nConnection: close\r\n\r\n`);
++  socket.destroy();
++}
++
++async function authenticateUpgrade(url: string): Promise<string | null> {
++  const m = SOCKET_PATH.exec(url);
++  if (!m) return null;
++  const query = new URLSearchParams(url.split('?')[1] ?? '');
++  const apiKey = query.get('api_key') ?? query.get('ApiKey') ?? '';
++  if (apiKey) {
++    const payload = readToken(apiKey);
++    if (payload) return verifyCredentials(payload.u, payload.p);
++  }
++  if (m[1] && m[2]) {
++    return verifyCredentials(decodeURIComponent(m[1]), m[2]);
++  }
++  return null;
++}
++
++export function attachJellyfinWebSocket(server: HttpServer): void {
++  const wss = new WebSocketServer({ noServer: true });
++  const perUser = new Map<string, number>();
++
++  wss.on('connection', (ws: WebSocket, _req: IncomingMessage, uuid: string) => {
++    perUser.set(uuid, (perUser.get(uuid) ?? 0) + 1);
++    const send = (MessageType: string, Data: unknown = null) => {
++      if (ws.readyState === ws.OPEN)
++        ws.send(JSON.stringify({ MessageType, Data }));
++    };
++    send('ForceKeepAlive', 60);
++    const timer = setInterval(() => send('KeepAlive'), 30_000);
++    const release = () => {
++      clearInterval(timer);
++      const n = (perUser.get(uuid) ?? 1) - 1;
++      if (n <= 0) perUser.delete(uuid);
++      else perUser.set(uuid, n);
++    };
++    ws.on('message', (raw) => {
++      try {
++        const msg = JSON.parse(String(raw)) as { MessageType?: string };
++        if (msg.MessageType === 'KeepAlive') send('KeepAlive');
++      } catch {}
++    });
++    ws.on('close', release);
++    ws.on('error', release);
++  });
++
++  server.on('upgrade', (req: IncomingMessage, socket: Duplex, head: Buffer) => {
++    const url = req.url ?? '';
++    if (!SOCKET_PATH.test(url)) return;
++    void authenticateUpgrade(url)
++      .then((uuid) => {
++        if (socket.destroyed) return;
++        if (!uuid) {
++          reject(socket, 401, 'Unauthorized');
++          return;
++        }
++        if ((perUser.get(uuid) ?? 0) >= MAX_SOCKETS_PER_USER) {
++          reject(socket, 429, 'Too Many Requests');
++          return;
++        }
++        if (wss.clients.size >= MAX_SOCKETS_TOTAL) {
++          reject(socket, 503, 'Service Unavailable');
++          return;
++        }
++        wss.handleUpgrade(req, socket, head, (ws) => {
++          wss.emit('connection', ws, req, uuid);
++        });
++      })
++      .catch((error) => {
++        logger.debug(
++          { err: error instanceof Error ? error.message : String(error) },
++          'websocket upgrade auth failed'
++        );
++        if (!socket.destroyed) reject(socket, 500, 'Internal Server Error');
++      });
++  });
++  logger.debug('jellyfin websocket attached');
++}
+diff --git a/packages/core/src/config/schema/api.ts b/packages/core/src/config/schema/api.ts
+index 7b3e96a8..bbc1fe3e 100644
+--- a/packages/core/src/config/schema/api.ts
++++ b/packages/core/src/config/schema/api.ts
+@@ -121,6 +121,46 @@ export const apiSchema = {
+     requiresRestart: true,
+     secret: false,
+   },
++  enableJellyfinApi: {
++    schema: z.boolean(),
++    default: true,
++    label: 'Enable Jellyfin-compatible API',
++    description:
++      'When true, a Jellyfin-compatible server API is exposed at /jellyfin (login with config UUID + password) and /jellyfin/<uuid>/<encryptedPassword> (pre-authenticated). Jellyfin clients (Swiftfin, Infuse, Findroid, Streamyfin, Jellyfin Android TV, Kodi…) can browse catalogs, see metadata, play streams directly and track watch progress.',
++    env: 'ENABLE_JELLYFIN_API',
++    requiresRestart: true,
++    secret: false,
++  },
++  jellyfinMaxCatalogItems: {
++    schema: z.number().int().min(0),
++    default: 1000,
++    label: 'Jellyfin: max items per library',
++    description:
++      'Upper bound on how many items a single catalog exposes to Jellyfin clients that crawl an entire library (Infuse, Kodi). Prevents infinite/discover catalogs from being paged forever. 0 disables the cap.',
++    env: 'JELLYFIN_MAX_CATALOG_ITEMS',
++    requiresRestart: false,
++    secret: false,
++  },
++  jellyfinLookupConcurrency: {
++    schema: z.number().int().min(1).max(64),
++    default: 8,
++    label: 'Jellyfin: lookup concurrency',
++    description:
++      'How many items a single Jellyfin list request (Resume, Favorites, Next Up, Latest, Ids query) resolves at once. Each item may still fan out to several addon calls, so this is a cap on parallel items, not on parallel upstream requests. Applies per request; higher is faster for the client but bursts harder on the configured addons.',
++    env: 'JELLYFIN_LOOKUP_CONCURRENCY',
++    requiresRestart: false,
++    secret: false,
++  },
++  jellyfinRelayTimeout: {
++    schema: z.number().int().min(1000),
++    default: 15000,
++    label: 'Jellyfin: relay timeout (ms)',
++    description:
++      'How long to wait for an upstream image or subtitle to start responding when Jellyfin clients fetch it through this server (milliseconds). Covers connection and headers only — once the response begins, the body streams at the client\u2019s pace and is never cut short.',
++    env: 'JELLYFIN_RELAY_TIMEOUT',
++    requiresRestart: false,
++    secret: false,
++  },
+   provideStreamData: {
+     schema: provideStreamData,
+     default: null,
+diff --git a/packages/core/src/db/repositories/users.ts b/packages/core/src/db/repositories/users.ts
+index eea947d5..335054ce 100644
+--- a/packages/core/src/db/repositories/users.ts
++++ b/packages/core/src/db/repositories/users.ts
+@@ -183,6 +183,31 @@ export class UserRepository {
+     }
+   }
+ 
++  static async verifyCredentials(
++    uuid: string,
++    password: string
++  ): Promise<boolean> {
++    try {
++      const row = await getDb().maybeOne<UserRow>(
++        sql`SELECT password_hash, config_salt FROM users WHERE uuid = ${uuid}`
++      );
++      if (!row) return false;
++      await this.resolveConfigKey(uuid, password, row);
++      return true;
++    } catch (error) {
++      if (
++        error instanceof APIError &&
++        error.code === constants.ErrorCode.USER_INVALID_DETAILS
++      ) {
++        return false;
++      }
++      if (error instanceof APIError) throw error;
++      const msg = error instanceof Error ? error.message : String(error);
++      logger.error(`Error verifying credentials for user ${uuid}: ${msg}`);
++      throw new APIError(constants.ErrorCode.DATABASE_ERROR);
++    }
++  }
++
+   static async getUser(
+     uuid: string,
+     password: string
+diff --git a/packages/core/src/index.ts b/packages/core/src/index.ts
+index 9e355dba..63f3a8c0 100644
+--- a/packages/core/src/index.ts
++++ b/packages/core/src/index.ts
+@@ -69,3 +69,4 @@ export type {
+   RunPlayChainConfig,
+   RunPlayChainResult,
+ } from './main/failover.js';
++export * from './jellyfin/index.js';
+diff --git a/packages/frontend/src/components/menu/save-install.tsx b/packages/frontend/src/components/menu/save-install.tsx
+index e753f2a5..1888aa27 100644
+--- a/packages/frontend/src/components/menu/save-install.tsx
++++ b/packages/frontend/src/components/menu/save-install.tsx
+@@ -582,9 +582,7 @@ function InstallCard({
+             <AppCard
+               logoSrc="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/refs/heads/master/logos/PNG-4x/jellyfin-icon--color-on-dark.png"
+               name="Jellyfin"
+-              description="Via Gelato plugin"
+-              unofficial
+-              author="lostb1t"
++              description="Connect Jellyfin apps directly"
+               onClick={onOpenJellyfin}
+             />
+             <AppCard
+@@ -2331,23 +2329,118 @@ function Content() {
+           open={jellyfinModal.isOpen}
+           onOpenChange={jellyfinModal.toggle}
+           title="AIOStreams for Jellyfin"
+-          description="Install the Gelato plugin to bring AIOStreams to Jellyfin"
++          description="Connect any Jellyfin client to this instance"
+         >
+           <div className="space-y-4">
+             <p className="text-sm text-gray-300">
+-              Gelato is an unofficial Jellyfin plugin that brings Stremio addons
+-              into Jellyfin.
++              Add this instance in any Jellyfin client (Jellyfin app, Swiftfin,
++              Findroid, Streamyfin, Infuse, …) with these details:
++            </p>
++            <div className="space-y-3">
++              <div className="space-y-1.5">
++                <label className="text-xs font-medium text-gray-400 ml-1">
++                  Server address
++                </label>
++                <div className="flex items-center gap-2">
++                  <TextInput
++                    type="text"
++                    readOnly
++                    value={`${baseUrl}/jellyfin`}
++                    className="flex-1 font-mono text-sm bg-black/20"
++                    onClick={(e) => e.currentTarget.select()}
++                  />
++                  <Button
++                    onClick={() => {
++                      copyToClipboard(`${baseUrl}/jellyfin`);
++                      toast.success('Server address copied');
++                    }}
++                    intent="primary"
++                    className="shrink-0 px-3"
++                    aria-label="Copy server address"
++                  >
++                    <CopyIcon className="h-4 w-4" />
++                  </Button>
++                </div>
++              </div>
++              <div className="space-y-1.5">
++                <label className="text-xs font-medium text-gray-400 ml-1">
++                  Username
++                </label>
++                <div className="flex items-center gap-2">
++                  <TextInput
++                    type="text"
++                    readOnly
++                    value={profileAlias ?? uuid ?? ''}
++                    className="flex-1 font-mono text-sm bg-black/20"
++                    onClick={(e) => e.currentTarget.select()}
++                  />
++                  <Button
++                    onClick={() => {
++                      copyToClipboard(profileAlias ?? uuid ?? '');
++                      toast.success('Username copied');
++                    }}
++                    intent="primary"
++                    className="shrink-0 px-3"
++                    aria-label="Copy username"
++                  >
++                    <CopyIcon className="h-4 w-4" />
++                  </Button>
++                </div>
++                <p className="text-xs text-gray-500 ml-1">
++                  {profileAlias
++                    ? 'Your profile alias doubles as your Jellyfin username; the UUID also works.'
++                    : 'Your configuration UUID is your username. Sign in on this page and set a profile alias to get a friendlier one.'}
++                </p>
++              </div>
++              <p className="text-xs text-gray-500 ml-1">
++                Password: the password of this configuration. Devices without a
++                comfortable keyboard can skip the login entirely with the
++                pre-authenticated address below (treat it like a password).
++              </p>
++              {uuid && encryptedPassword && (
++                <div className="space-y-1.5">
++                  <label className="text-xs font-medium text-gray-400 ml-1">
++                    Pre-authenticated server address
++                  </label>
++                  <div className="flex items-center gap-2">
++                    <TextInput
++                      type="text"
++                      readOnly
++                      value={`${baseUrl}/jellyfin/${uuid}/${encryptedPassword}`}
++                      className="flex-1 font-mono text-sm bg-black/20"
++                      onClick={(e) => e.currentTarget.select()}
++                    />
++                    <Button
++                      onClick={() => {
++                        copyToClipboard(
++                          `${baseUrl}/jellyfin/${uuid}/${encryptedPassword}`
++                        );
++                        toast.success('Pre-authenticated address copied');
++                      }}
++                      intent="primary"
++                      className="shrink-0 px-3"
++                      aria-label="Copy pre-authenticated address"
++                    >
++                      <CopyIcon className="h-4 w-4" />
++                    </Button>
++                  </div>
++                </div>
++              )}
++            </div>
++            <p className="text-xs text-gray-500">
++              Direct play only (no transcoding) — a catalog/metadata addon (e.g.
++              TMDB or Cinemeta) fills your libraries, and a debrid or usenet
++              service makes results playable. Alternatively, the unofficial{' '}
++              <a
++                href="https://github.com/lostb1t/Gelato"
++                target="_blank"
++                rel="noopener noreferrer"
++                className="underline hover:text-gray-300"
++              >
++                Gelato plugin
++              </a>{' '}
++              brings Stremio addons into a real Jellyfin server.
+             </p>
+-            <Button
+-              intent="primary"
+-              className="w-full"
+-              leftIcon={<FiExternalLink />}
+-              onClick={() =>
+-                window.open('https://github.com/lostb1t/Gelato', '_blank')
+-              }
+-            >
+-              Open Gelato on GitHub
+-            </Button>
+           </div>
+         </Modal>
+ 
+diff --git a/packages/server/src/app.ts b/packages/server/src/app.ts
+index 664a2417..8a39f737 100644
+--- a/packages/server/src/app.ts
++++ b/packages/server/src/app.ts
+@@ -28,6 +28,7 @@ import {
+   addonCatalog,
+   alias,
+ } from './routes/stremio/index.js';
++import { createJellyfinRouter } from './routes/jellyfin/index.js';
+ import {
+   manifest as chillLinkManifest,
+   streams as chillLinkStreams,
+@@ -242,6 +243,25 @@ app.use(
+ );
+ app.use('/chilllink/:uuid/:encryptedPassword', chillLinkRouter);
+ 
++const jellyfinGate: express.RequestHandler = (req, res, next) => {
++  if (!appConfig.api.enableJellyfinApi) {
++    res.status(404).json({ Message: 'Jellyfin API is disabled' });
++    return;
++  }
++  next();
++};
++app.use(
++  `/jellyfin/:uuid/:encryptedPassword${VARIANT_PATH_ROUTE}`,
++  jellyfinGate,
++  createJellyfinRouter()
++);
++app.use(
++  '/jellyfin/:uuid/:encryptedPassword',
++  jellyfinGate,
++  createJellyfinRouter()
++);
++app.use('/jellyfin', jellyfinGate, createJellyfinRouter());
++
+ const seanimeRouter = express.Router({ mergeParams: true });
+ seanimeRouter.use(corsMiddleware);
+ seanimeRouter.use(seanimeExtensionsRouter);
+diff --git a/packages/server/src/express.d.ts b/packages/server/src/express.d.ts
+index 7545cde5..f3094172 100644
+--- a/packages/server/src/express.d.ts
++++ b/packages/server/src/express.d.ts
+@@ -1,6 +1,7 @@
+ import 'express';
+ import { UserData, SessionUser } from '@aiostreams/core';
+ import type { RateLimitInfo } from 'express-rate-limit';
++import type { JellyfinRequestContext } from './routes/jellyfin/context.js';
+ 
+ declare global {
+   namespace Express {
+@@ -11,6 +12,8 @@ declare global {
+       uuid?: string;
+       user?: SessionUser;
+       rateLimit?: RateLimitInfo;
++      jf?: JellyfinRequestContext;
++      jfLazy?: () => Promise<JellyfinRequestContext | null>;
+     }
+   }
+ }
+diff --git a/packages/core/src/db/index.ts b/packages/core/src/db/index.ts
+index d9d8afb7..e0d2b363 100644
+--- a/packages/core/src/db/index.ts
++++ b/packages/core/src/db/index.ts
+@@ -1,5 +1,10 @@
+ export { initDb, getDb, closeDb } from './db.js';
+ export { UserRepository } from './repositories/users.js';
++export {
++  JellyfinRepository,
++  type JellyfinItemDescriptor,
++  type JellyfinPlaystateRow,
++} from './repositories/jellyfin.js';
+ export {
+   AdminUsersRepository,
+   type AdminUserListItem,
+diff --git a/packages/core/src/utils/concurrency.test.ts b/packages/core/src/utils/concurrency.test.ts
+new file mode 100644
+index 00000000..8312a21d
+--- /dev/null
++++ b/packages/core/src/utils/concurrency.test.ts
+@@ -0,0 +1,90 @@
++import { describe, it } from 'node:test';
++import assert from 'node:assert/strict';
++import { collectConcurrent } from './concurrency.js';
++
++const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
++
++describe('collectConcurrent', () => {
++  it('keeps input order regardless of completion order', async () => {
++    const out = await collectConcurrent(
++      [50, 1, 40, 2, 30, 3],
++      async (d, i) => {
++        await sleep(d);
++        return [i];
++      },
++      { concurrency: 3 }
++    );
++    assert.deepEqual(out, [0, 1, 2, 3, 4, 5]);
++  });
++
++  it('never exceeds the configured concurrency', async () => {
++    let live = 0;
++    let peak = 0;
++    await collectConcurrent(
++      Array.from({ length: 40 }, (_, i) => i),
++      async () => {
++        live++;
++        peak = Math.max(peak, live);
++        await sleep(5);
++        live--;
++        return [1];
++      },
++      { concurrency: 4 }
++    );
++    assert.equal(peak, 4);
++  });
++
++  it('stops claiming work once the target is met', async () => {
++    let started = 0;
++    const out = await collectConcurrent(
++      Array.from({ length: 100 }, (_, i) => i),
++      async () => {
++        started++;
++        await sleep(2);
++        return [1, 1];
++      },
++      { concurrency: 4, target: 10 }
++    );
++    assert.ok(out.length >= 10);
++    assert.ok(started < 20, `started ${started}`);
++  });
++
++  it('does not let one slow item hold back the ones behind it', async () => {
++    const finished: number[] = [];
++    await collectConcurrent(
++      [200, 1, 1, 1, 1, 1],
++      async (d, i) => {
++        await sleep(d);
++        finished.push(i);
++        return [i];
++      },
++      { concurrency: 2 }
++    );
++    assert.equal(finished.at(-1), 0);
++  });
++
++  it('skips a throwing item without failing the batch', async () => {
++    const errors: string[] = [];
++    const out = await collectConcurrent(
++      [1, 2, 3, 4],
++      async (n) => {
++        if (n % 2 === 0) throw new Error(`boom ${n}`);
++        return [n];
++      },
++      { concurrency: 2, onError: (e) => errors.push((e as Error).message) }
++    );
++    assert.deepEqual(out, [1, 3]);
++    assert.deepEqual(errors, ['boom 2', 'boom 4']);
++  });
++
++  it('handles empty input and clamps a nonsensical concurrency', async () => {
++    assert.deepEqual(
++      await collectConcurrent([], async () => [1], { concurrency: 8 }),
++      []
++    );
++    assert.deepEqual(
++      await collectConcurrent([1, 2, 3], async (n) => [n], { concurrency: 0 }),
++      [1, 2, 3]
++    );
++  });
++});
+diff --git a/packages/core/src/utils/concurrency.ts b/packages/core/src/utils/concurrency.ts
+new file mode 100644
+index 00000000..ac4b7602
+--- /dev/null
++++ b/packages/core/src/utils/concurrency.ts
+@@ -0,0 +1,33 @@
++export async function collectConcurrent<T, R>(
++  items: readonly T[],
++  fn: (item: T, index: number) => Promise<R[]>,
++  opts: {
++    concurrency: number;
++    target?: number;
++    onError?: (error: unknown, item: T, index: number) => void;
++  }
++): Promise<R[]> {
++  const concurrency = Math.max(1, Math.trunc(opts.concurrency));
++  const target = opts.target ?? Infinity;
++  const results: R[][] = items.map(() => []);
++  let cursor = 0;
++  let collected = 0;
++
++  const worker = async (): Promise<void> => {
++    while (cursor < items.length && collected < target) {
++      const index = cursor++;
++      try {
++        const batch = await fn(items[index], index);
++        results[index] = batch;
++        collected += batch.length;
++      } catch (error) {
++        opts.onError?.(error, items[index], index);
++      }
++    }
++  };
++
++  await Promise.all(
++    Array.from({ length: Math.min(concurrency, items.length) }, worker)
++  );
++  return results.flat();
++}
+diff --git a/packages/core/src/utils/index.ts b/packages/core/src/utils/index.ts
+index e52e8dba..4ff07d34 100644
+--- a/packages/core/src/utils/index.ts
++++ b/packages/core/src/utils/index.ts
+@@ -1,4 +1,5 @@
+ export * from './cache.js';
++export * from './concurrency.js';
+ export * from './constants.js';
+ export * from './env.js';
+ export * from '../logging/logger.js';

--- a/packages/core/src/config/schema/api.ts
+++ b/packages/core/src/config/schema/api.ts
@@ -151,6 +151,46 @@ export const apiSchema = {
     requiresRestart: true,
     secret: false,
   },
+  enableJellyfinApi: {
+    schema: z.boolean(),
+    default: true,
+    label: 'Enable Jellyfin-compatible API',
+    description:
+      'When true, a Jellyfin-compatible server API is exposed at /jellyfin (login with config UUID + password) and /jellyfin/<uuid>/<encryptedPassword> (pre-authenticated). Jellyfin clients (Swiftfin, Infuse, Findroid, Streamyfin, Jellyfin Android TV, Kodi…) can browse catalogs, see metadata, play streams directly and track watch progress.',
+    env: 'ENABLE_JELLYFIN_API',
+    requiresRestart: true,
+    secret: false,
+  },
+  jellyfinMaxCatalogItems: {
+    schema: z.number().int().min(0),
+    default: 1000,
+    label: 'Jellyfin: max items per library',
+    description:
+      'Upper bound on how many items a single catalog exposes to Jellyfin clients that crawl an entire library (Infuse, Kodi). Prevents infinite/discover catalogs from being paged forever. 0 disables the cap.',
+    env: 'JELLYFIN_MAX_CATALOG_ITEMS',
+    requiresRestart: false,
+    secret: false,
+  },
+  jellyfinLookupConcurrency: {
+    schema: z.number().int().min(1).max(64),
+    default: 8,
+    label: 'Jellyfin: lookup concurrency',
+    description:
+      'How many items a single Jellyfin list request (Resume, Favorites, Next Up, Latest, Ids query) resolves at once. Each item may still fan out to several addon calls, so this is a cap on parallel items, not on parallel upstream requests. Applies per request; higher is faster for the client but bursts harder on the configured addons.',
+    env: 'JELLYFIN_LOOKUP_CONCURRENCY',
+    requiresRestart: false,
+    secret: false,
+  },
+  jellyfinRelayTimeout: {
+    schema: z.number().int().min(1000),
+    default: 15000,
+    label: 'Jellyfin: relay timeout (ms)',
+    description:
+      'How long to wait for an upstream image or subtitle to start responding when Jellyfin clients fetch it through this server (milliseconds). Covers connection and headers only — once the response begins, the body streams at the client\u2019s pace and is never cut short.',
+    env: 'JELLYFIN_RELAY_TIMEOUT',
+    requiresRestart: false,
+    secret: false,
+  },
   provideStreamData: {
     schema: provideStreamData,
     default: null,

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -1,6 +1,11 @@
 export { initDb, getDb, closeDb } from './db.js';
 export { UserRepository } from './repositories/users.js';
 export {
+  JellyfinRepository,
+  type JellyfinItemDescriptor,
+  type JellyfinPlaystateRow,
+} from './repositories/jellyfin.js';
+export {
   AdminUsersRepository,
   type AdminUserListItem,
   type AdminUserDetail,

--- a/packages/core/src/db/migrations/0027_jellyfin.ts
+++ b/packages/core/src/db/migrations/0027_jellyfin.ts
@@ -1,0 +1,74 @@
+import type { Migration } from './types.js';
+
+export const jellyfin: Migration = {
+  id: 27,
+  name: 'jellyfin',
+  up: {
+    sqlite: `
+      CREATE TABLE IF NOT EXISTS jellyfin_items (
+        id          TEXT PRIMARY KEY,
+        payload     TEXT NOT NULL,
+        created_at  INTEGER NOT NULL DEFAULT 0
+      );
+
+      CREATE TABLE IF NOT EXISTS jellyfin_playstate (
+        uuid             TEXT NOT NULL REFERENCES users(uuid) ON DELETE CASCADE,
+        item_id          TEXT NOT NULL,
+        payload          TEXT NOT NULL,
+        position_ticks   INTEGER NOT NULL DEFAULT 0,
+        runtime_ticks    INTEGER NOT NULL DEFAULT 0,
+        played           INTEGER NOT NULL DEFAULT 0,
+        play_count       INTEGER NOT NULL DEFAULT 0,
+        favorite         INTEGER NOT NULL DEFAULT 0,
+        last_played_at   INTEGER,
+        updated_at       INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (uuid, item_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_jellyfin_playstate_uuid_updated
+        ON jellyfin_playstate (uuid, updated_at DESC);
+
+      CREATE TABLE IF NOT EXISTS jellyfin_display_prefs (
+        uuid        TEXT NOT NULL REFERENCES users(uuid) ON DELETE CASCADE,
+        pref_id     TEXT NOT NULL,
+        client      TEXT NOT NULL,
+        payload     TEXT NOT NULL,
+        updated_at  INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (uuid, pref_id, client)
+      );
+    `,
+    postgres: `
+      CREATE TABLE IF NOT EXISTS jellyfin_items (
+        id          TEXT PRIMARY KEY,
+        payload     TEXT NOT NULL,
+        created_at  BIGINT NOT NULL DEFAULT 0
+      );
+
+      CREATE TABLE IF NOT EXISTS jellyfin_playstate (
+        uuid             TEXT NOT NULL REFERENCES users(uuid) ON DELETE CASCADE,
+        item_id          TEXT NOT NULL,
+        payload          TEXT NOT NULL,
+        position_ticks   BIGINT NOT NULL DEFAULT 0,
+        runtime_ticks    BIGINT NOT NULL DEFAULT 0,
+        played           INTEGER NOT NULL DEFAULT 0,
+        play_count       INTEGER NOT NULL DEFAULT 0,
+        favorite         INTEGER NOT NULL DEFAULT 0,
+        last_played_at   BIGINT,
+        updated_at       BIGINT NOT NULL DEFAULT 0,
+        PRIMARY KEY (uuid, item_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_jellyfin_playstate_uuid_updated
+        ON jellyfin_playstate (uuid, updated_at DESC);
+
+      CREATE TABLE IF NOT EXISTS jellyfin_display_prefs (
+        uuid        TEXT NOT NULL REFERENCES users(uuid) ON DELETE CASCADE,
+        pref_id     TEXT NOT NULL,
+        client      TEXT NOT NULL,
+        payload     TEXT NOT NULL,
+        updated_at  BIGINT NOT NULL DEFAULT 0,
+        PRIMARY KEY (uuid, pref_id, client)
+      );
+    `,
+  },
+};

--- a/packages/core/src/db/migrations/0028_jellyfin_keys.ts
+++ b/packages/core/src/db/migrations/0028_jellyfin_keys.ts
@@ -1,0 +1,34 @@
+import type { Migration } from './types.js';
+
+export const jellyfinKeys: Migration = {
+  id: 28,
+  name: 'jellyfin_keys',
+  up: {
+    sqlite: `
+      ALTER TABLE jellyfin_playstate ADD COLUMN series_key TEXT;
+
+      UPDATE jellyfin_playstate
+         SET series_key = json_extract(payload, '$.t') || '|' || json_extract(payload, '$.i')
+       WHERE json_extract(payload, '$.k') = 'episode';
+
+      CREATE INDEX IF NOT EXISTS idx_jellyfin_playstate_series
+        ON jellyfin_playstate (uuid, series_key);
+
+      CREATE INDEX IF NOT EXISTS idx_jellyfin_items_created
+        ON jellyfin_items (created_at);
+    `,
+    postgres: `
+      ALTER TABLE jellyfin_playstate ADD COLUMN IF NOT EXISTS series_key TEXT;
+
+      UPDATE jellyfin_playstate
+         SET series_key = (payload::jsonb ->> 't') || '|' || (payload::jsonb ->> 'i')
+       WHERE payload::jsonb ->> 'k' = 'episode';
+
+      CREATE INDEX IF NOT EXISTS idx_jellyfin_playstate_series
+        ON jellyfin_playstate (uuid, series_key);
+
+      CREATE INDEX IF NOT EXISTS idx_jellyfin_items_created
+        ON jellyfin_items (created_at);
+    `,
+  },
+};

--- a/packages/core/src/db/migrations/index.ts
+++ b/packages/core/src/db/migrations/index.ts
@@ -24,6 +24,8 @@ import { linkedAccounts } from './0023_linked_accounts.js';
 import { community } from './0024_community.js';
 import { configSessions } from './0025_config_sessions.js';
 import { usenetLibraryArr } from './0026_usenet_library_arr.js';
+import { jellyfin } from './0027_jellyfin.js';
+import { jellyfinKeys } from './0028_jellyfin_keys.js';
 import type { Migration } from './types.js';
 
 export const MIGRATIONS: readonly Migration[] = [
@@ -53,6 +55,8 @@ export const MIGRATIONS: readonly Migration[] = [
   community,
   configSessions,
   usenetLibraryArr,
+  jellyfin,
+  jellyfinKeys,
 ];
 
 export type { Migration } from './types.js';

--- a/packages/core/src/db/repositories/jellyfin.ts
+++ b/packages/core/src/db/repositories/jellyfin.ts
@@ -1,0 +1,324 @@
+import { getDb } from '../db.js';
+import { join, sql } from '../sql.js';
+
+export type JellyfinItemDescriptor =
+  | { k: 'view'; t: string; c: string }
+  | { k: 'genre'; t: string; c: string; g: string }
+  | { k: 'movie'; t: string; i: string }
+  | { k: 'series'; t: string; i: string }
+  | { k: 'season'; t: string; i: string; s: number }
+  | { k: 'episode'; t: string; i: string; s: number; e: number; v: string }
+  | { k: 'person'; n: string }
+  | { k: 'studio'; n: string };
+
+export interface JellyfinPlaystateRow {
+  itemId: string;
+  payload: JellyfinItemDescriptor;
+  positionTicks: number;
+  runtimeTicks: number;
+  played: boolean;
+  playCount: number;
+  favorite: boolean;
+  lastPlayedAt: number | null;
+  updatedAt: number;
+}
+
+interface PlaystateDbRow {
+  item_id: string;
+  payload: string;
+  position_ticks: number | string;
+  runtime_ticks: number | string;
+  played: number | boolean;
+  play_count: number | string;
+  favorite: number | boolean;
+  last_played_at: number | string | null;
+  updated_at: number | string;
+  [k: string]: unknown;
+}
+
+function toPlaystate(r: PlaystateDbRow): JellyfinPlaystateRow {
+  return {
+    itemId: r.item_id,
+    payload: JSON.parse(r.payload),
+    positionTicks: Number(r.position_ticks),
+    runtimeTicks: Number(r.runtime_ticks),
+    played: Boolean(Number(r.played)),
+    playCount: Number(r.play_count),
+    favorite: Boolean(Number(r.favorite)),
+    lastPlayedAt: r.last_played_at == null ? null : Number(r.last_played_at),
+    updatedAt: Number(r.updated_at),
+  };
+}
+
+const CHUNK = 200;
+
+function seriesKeyFor(d: JellyfinItemDescriptor): string | null {
+  return d.k === 'episode' ? `${d.t}|${d.i}` : null;
+}
+
+export class JellyfinRepository {
+  static async userVersions(uuids: string[]): Promise<Map<string, string>> {
+    const out = new Map<string, string>();
+    const wanted = [...new Set(uuids.filter(Boolean))];
+    if (!wanted.length) return out;
+    const rows = await getDb().query<{
+      uuid: string;
+      updated_at: string | Date | null;
+    }>(
+      sql`SELECT uuid, updated_at FROM users
+           WHERE uuid IN (${join(wanted.map((u) => sql`${u}`))})`
+    );
+    for (const r of rows) {
+      out.set(
+        r.uuid,
+        r.updated_at instanceof Date
+          ? r.updated_at.toISOString()
+          : String(r.updated_at ?? '')
+      );
+    }
+    return out;
+  }
+
+  static async rememberItems(
+    entries: { id: string; payload: JellyfinItemDescriptor }[]
+  ): Promise<void> {
+    if (!entries.length) return;
+    const now = Date.now();
+    for (let i = 0; i < entries.length; i += CHUNK) {
+      const slice = entries.slice(i, i + CHUNK);
+      const values = join(
+        slice.map((e) => sql`(${e.id}, ${JSON.stringify(e.payload)}, ${now})`)
+      );
+      await getDb().exec(
+        sql`INSERT INTO jellyfin_items (id, payload, created_at)
+            VALUES ${values}
+            ON CONFLICT(id) DO NOTHING`
+      );
+    }
+  }
+
+  static async lookupItem(id: string): Promise<JellyfinItemDescriptor | null> {
+    const row = await getDb().maybeOne<{ payload: string }>(
+      sql`SELECT payload FROM jellyfin_items WHERE id = ${id}`
+    );
+    return row ? (JSON.parse(row.payload) as JellyfinItemDescriptor) : null;
+  }
+
+  static async getPlaystates(
+    uuid: string,
+    itemIds: string[]
+  ): Promise<Map<string, JellyfinPlaystateRow>> {
+    const out = new Map<string, JellyfinPlaystateRow>();
+    if (!itemIds.length) return out;
+    for (let i = 0; i < itemIds.length; i += CHUNK) {
+      const slice = itemIds.slice(i, i + CHUNK);
+      const rows = await getDb().query<PlaystateDbRow>(
+        sql`SELECT * FROM jellyfin_playstate
+             WHERE uuid = ${uuid} AND item_id IN (${join(slice.map((id) => sql`${id}`))})`
+      );
+      for (const r of rows) out.set(r.item_id, toPlaystate(r));
+    }
+    return out;
+  }
+
+  static async getPlaystate(
+    uuid: string,
+    itemId: string
+  ): Promise<JellyfinPlaystateRow | null> {
+    const row = await getDb().maybeOne<PlaystateDbRow>(
+      sql`SELECT * FROM jellyfin_playstate WHERE uuid = ${uuid} AND item_id = ${itemId}`
+    );
+    return row ? toPlaystate(row) : null;
+  }
+
+  static async upsertPlaystate(
+    uuid: string,
+    itemId: string,
+    payload: JellyfinItemDescriptor,
+    patch: {
+      positionTicks?: number;
+      runtimeTicks?: number;
+      played?: boolean;
+      incrementPlayCount?: boolean | 'if-unplayed';
+      favorite?: boolean;
+      lastPlayedAt?: number | null;
+    }
+  ): Promise<JellyfinPlaystateRow> {
+    const now = Date.now();
+    const pos = patch.positionTicks ?? null;
+    const rt = patch.runtimeTicks ?? null;
+    const played = patch.played == null ? null : patch.played ? 1 : 0;
+    const fav = patch.favorite == null ? null : patch.favorite ? 1 : 0;
+    const incMode =
+      patch.incrementPlayCount === 'if-unplayed'
+        ? 2
+        : patch.incrementPlayCount
+          ? 1
+          : 0;
+    const setLastPlayed = patch.lastPlayedAt === undefined ? 0 : 1;
+    const lastPlayed = patch.lastPlayedAt ?? null;
+    const seriesKey = seriesKeyFor(payload);
+    await getDb().exec(
+      sql`INSERT INTO jellyfin_playstate
+            (uuid, item_id, payload, series_key, position_ticks, runtime_ticks, played, play_count, favorite, last_played_at, updated_at)
+          VALUES (${uuid}, ${itemId}, ${JSON.stringify(payload)}, ${seriesKey},
+                  COALESCE(${pos}, 0), COALESCE(${rt}, 0), COALESCE(${played}, 0),
+                  CASE WHEN ${incMode} > 0 THEN 1 ELSE 0 END,
+                  COALESCE(${fav}, 0), ${lastPlayed}, ${now})
+          ON CONFLICT(uuid, item_id) DO UPDATE SET
+            payload = excluded.payload,
+            series_key = excluded.series_key,
+            position_ticks = COALESCE(${pos}, jellyfin_playstate.position_ticks),
+            runtime_ticks = COALESCE(${rt}, jellyfin_playstate.runtime_ticks),
+            played = COALESCE(${played}, jellyfin_playstate.played),
+            play_count = jellyfin_playstate.play_count +
+              CASE ${incMode}
+                WHEN 1 THEN 1
+                WHEN 2 THEN CASE WHEN jellyfin_playstate.played = 1 THEN 0 ELSE 1 END
+                ELSE 0
+              END,
+            favorite = COALESCE(${fav}, jellyfin_playstate.favorite),
+            last_played_at = CASE WHEN ${setLastPlayed} = 1 THEN ${lastPlayed} ELSE jellyfin_playstate.last_played_at END,
+            updated_at = excluded.updated_at`
+    );
+    const row = await this.getPlaystate(uuid, itemId);
+    if (row) return row;
+    return {
+      itemId,
+      payload,
+      positionTicks: pos ?? 0,
+      runtimeTicks: rt ?? 0,
+      played: !!played,
+      playCount: incMode > 0 ? 1 : 0,
+      favorite: !!fav,
+      lastPlayedAt: lastPlayed,
+      updatedAt: now,
+    };
+  }
+
+  static async deletePlaystate(uuid: string, itemId: string): Promise<void> {
+    await getDb().exec(
+      sql`DELETE FROM jellyfin_playstate WHERE uuid = ${uuid} AND item_id = ${itemId}`
+    );
+  }
+
+  static async listResume(
+    uuid: string,
+    limit: number,
+    kinds: string[] = ['movie', 'episode']
+  ): Promise<JellyfinPlaystateRow[]> {
+    const rows = await getDb().query<PlaystateDbRow>(
+      sql`SELECT * FROM jellyfin_playstate
+           WHERE uuid = ${uuid} AND played = 0 AND position_ticks > 0
+           ORDER BY updated_at DESC
+           LIMIT ${Math.max(limit * 3, 30)}`
+    );
+    return rows
+      .map(toPlaystate)
+      .filter((r) => kinds.includes(r.payload.k))
+      .slice(0, limit);
+  }
+
+  static async listRecentEpisodesBySeries(
+    uuid: string,
+    limit: number
+  ): Promise<JellyfinPlaystateRow[]> {
+    const rows = await getDb().query<PlaystateDbRow>(
+      sql`SELECT * FROM jellyfin_playstate
+           WHERE uuid = ${uuid} AND (played = 1 OR position_ticks > 0)
+           ORDER BY updated_at DESC
+           LIMIT 500`
+    );
+    const seen = new Set<string>();
+    const out: JellyfinPlaystateRow[] = [];
+    for (const r of rows.map(toPlaystate)) {
+      if (r.payload.k !== 'episode') continue;
+      const key = `${r.payload.t}|${r.payload.i}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(r);
+      if (out.length >= limit) break;
+    }
+    return out;
+  }
+
+  static async listFavorites(
+    uuid: string,
+    kinds?: string[]
+  ): Promise<JellyfinPlaystateRow[]> {
+    const rows = await getDb().query<PlaystateDbRow>(
+      sql`SELECT * FROM jellyfin_playstate
+           WHERE uuid = ${uuid} AND favorite = 1
+           ORDER BY updated_at DESC
+           LIMIT 500`
+    );
+    return rows
+      .map(toPlaystate)
+      .filter((r) => !kinds || kinds.includes(r.payload.k));
+  }
+
+  static async listPlayed(
+    uuid: string,
+    kinds?: string[]
+  ): Promise<JellyfinPlaystateRow[]> {
+    const rows = await getDb().query<PlaystateDbRow>(
+      sql`SELECT * FROM jellyfin_playstate
+           WHERE uuid = ${uuid} AND played = 1
+           ORDER BY updated_at DESC
+           LIMIT 500`
+    );
+    return rows
+      .map(toPlaystate)
+      .filter((r) => !kinds || kinds.includes(r.payload.k));
+  }
+
+  static async listForSeries(
+    uuid: string,
+    type: string,
+    seriesId: string
+  ): Promise<JellyfinPlaystateRow[]> {
+    const rows = await getDb().query<PlaystateDbRow>(
+      sql`SELECT * FROM jellyfin_playstate
+           WHERE uuid = ${uuid} AND series_key = ${`${type}|${seriesId}`}`
+    );
+    return rows.map(toPlaystate).filter((r) => r.payload.k === 'episode');
+  }
+
+  static async pruneItems(maxAgeMs: number): Promise<number> {
+    const cutoff = Date.now() - maxAgeMs;
+    const res = await getDb().exec(
+      sql`DELETE FROM jellyfin_items
+           WHERE created_at < ${cutoff}
+             AND NOT EXISTS (
+               SELECT 1 FROM jellyfin_playstate p WHERE p.item_id = jellyfin_items.id
+             )`
+    );
+    return res.rowCount;
+  }
+
+  static async getDisplayPrefs(
+    uuid: string,
+    prefId: string,
+    client: string
+  ): Promise<Record<string, unknown> | null> {
+    const row = await getDb().maybeOne<{ payload: string }>(
+      sql`SELECT payload FROM jellyfin_display_prefs
+           WHERE uuid = ${uuid} AND pref_id = ${prefId} AND client = ${client}`
+    );
+    return row ? JSON.parse(row.payload) : null;
+  }
+
+  static async setDisplayPrefs(
+    uuid: string,
+    prefId: string,
+    client: string,
+    payload: Record<string, unknown>
+  ): Promise<void> {
+    await getDb().exec(
+      sql`INSERT INTO jellyfin_display_prefs (uuid, pref_id, client, payload, updated_at)
+          VALUES (${uuid}, ${prefId}, ${client}, ${JSON.stringify(payload)}, ${Date.now()})
+          ON CONFLICT(uuid, pref_id, client) DO UPDATE SET
+            payload = excluded.payload, updated_at = excluded.updated_at`
+    );
+  }
+}

--- a/packages/core/src/db/repositories/users.ts
+++ b/packages/core/src/db/repositories/users.ts
@@ -187,6 +187,31 @@ export class UserRepository {
     }
   }
 
+  static async verifyCredentials(
+    uuid: string,
+    password: string
+  ): Promise<boolean> {
+    try {
+      const row = await getDb().maybeOne<UserRow>(
+        sql`SELECT password_hash, config_salt FROM users WHERE uuid = ${uuid}`
+      );
+      if (!row) return false;
+      await this.resolveConfigKey(uuid, password, row);
+      return true;
+    } catch (error) {
+      if (
+        error instanceof APIError &&
+        error.code === constants.ErrorCode.USER_INVALID_DETAILS
+      ) {
+        return false;
+      }
+      if (error instanceof APIError) throw error;
+      const msg = error instanceof Error ? error.message : String(error);
+      logger.error(`Error verifying credentials for user ${uuid}: ${msg}`);
+      throw new APIError(constants.ErrorCode.DATABASE_ERROR);
+    }
+  }
+
   static async getUser(
     uuid: string,
     password: string

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,3 +75,4 @@ export type {
   RunPlayChainConfig,
   RunPlayChainResult,
 } from './main/failover.js';
+export * from './jellyfin/index.js';

--- a/packages/core/src/jellyfin/dto.ts
+++ b/packages/core/src/jellyfin/dto.ts
@@ -1,0 +1,1088 @@
+import type {
+  Manifest,
+  Meta,
+  MetaPreview,
+  ParsedMeta,
+  ParsedStream,
+  Subtitle,
+} from '../db/schemas.js';
+import type {
+  JellyfinItemDescriptor,
+  JellyfinPlaystateRow,
+} from '../db/repositories/jellyfin.js';
+import { IdParser } from '../utils/id-parser.js';
+import { languageToCode } from '../utils/languages.js';
+import { encodeJellyfinId, imageTag, streamIdToMediaSourceId } from './ids.js';
+import { rememberImages, type ItemImages } from './images.js';
+
+export const TICKS_PER_MS = 10_000;
+export const TICKS_PER_SECOND = 10_000_000;
+export const TICKS_PER_MINUTE = 600_000_000;
+
+export type JellyfinItemType =
+  | 'Movie'
+  | 'Series'
+  | 'Season'
+  | 'Episode'
+  | 'CollectionFolder'
+  | 'Folder'
+  | 'Genre'
+  | 'Person'
+  | 'Studio'
+  | 'Video';
+
+export type JellyfinUserItemData = {
+  PlaybackPositionTicks: number;
+  PlayCount: number;
+  IsFavorite: boolean;
+  Played: boolean;
+  LastPlayedDate?: string;
+  PlayedPercentage?: number;
+  UnplayedItemCount?: number;
+  Key: string;
+  ItemId: string;
+};
+
+export type JellyfinItem = {
+  Id: string;
+  Name: string;
+  ServerId: string;
+  Type: JellyfinItemType;
+  IsFolder: boolean;
+  [key: string]: unknown;
+};
+
+export type JellyfinMediaStream = {
+  Type: 'Video' | 'Audio' | 'Subtitle';
+  Index: number;
+  Codec?: string;
+  Language?: string;
+  DisplayTitle?: string;
+  IsDefault?: boolean;
+  IsForced?: boolean;
+  IsExternal?: boolean;
+  [key: string]: unknown;
+};
+
+export type JellyfinMediaSource = {
+  Id: string;
+  Name: string;
+  Path: string;
+  Protocol: 'Http' | 'File';
+  [key: string]: unknown;
+};
+
+export interface ItemBuildContext {
+  uuid: string;
+  serverId: string;
+}
+
+export function parseRuntimeToTicks(
+  runtime: string | number | null | undefined
+): number | undefined {
+  if (runtime == null) return undefined;
+  if (typeof runtime === 'number') return runtime * TICKS_PER_MINUTE;
+  const s = runtime.toLowerCase();
+  let minutes = 0;
+  const h = s.match(/(\d+)\s*h/);
+  const m = s.match(/(\d+)\s*m/);
+  if (h) minutes += Number(h[1]) * 60;
+  if (m) minutes += Number(m[1]);
+  if (!h && !m) {
+    const n = s.match(/(\d+)/);
+    if (n) minutes = Number(n[1]);
+  }
+  return minutes > 0 ? minutes * TICKS_PER_MINUTE : undefined;
+}
+
+function parseYear(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  const m = String(value).match(/(\d{4})/);
+  return m ? Number(m[1]) : undefined;
+}
+
+function parseReleaseStatus(
+  value: unknown
+): 'Continuing' | 'Ended' | undefined {
+  if (value == null) return undefined;
+  const s = String(value);
+  if (/\d{4}\s*[-–]\s*$/.test(s)) return 'Continuing';
+  if (/\d{4}\s*[-–]\s*\d{4}/.test(s)) return 'Ended';
+  return undefined;
+}
+
+function toIso(date: unknown): string | undefined {
+  if (!date) return undefined;
+  const d = new Date(String(date));
+  return isNaN(d.getTime()) ? undefined : d.toISOString();
+}
+
+function numberOr(value: unknown): number | undefined {
+  if (value == null || value === '') return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function linksByCategory(meta: MetaPreview | Meta, category: string): string[] {
+  return (meta.links ?? [])
+    .filter((l) => l.category.toLowerCase() === category.toLowerCase())
+    .map((l) => l.name);
+}
+
+export function providerIdsFor(
+  meta: MetaPreview | Meta | { id: string; type: string }
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  const parsed = IdParser.parse(meta.id, meta.type);
+  if (parsed) {
+    const v = String(parsed.value);
+    switch (parsed.type) {
+      case 'imdbId':
+        out.Imdb = v.startsWith('tt') ? v : `tt${v}`;
+        break;
+      case 'themoviedbId':
+        out.Tmdb = v;
+        break;
+      case 'thetvdbId':
+        out.Tvdb = v;
+        break;
+      case 'kitsuId':
+        out.Kitsu = v;
+        break;
+      case 'malId':
+        out.MyAnimeList = v;
+        break;
+      case 'anilistId':
+        out.AniList = v;
+        break;
+      case 'anidbId':
+        out.AniDB = v;
+        break;
+      case 'simklId':
+        out.Simkl = v;
+        break;
+    }
+  }
+  const any = meta as Record<string, unknown>;
+  if (typeof any.imdb_id === 'string' && !out.Imdb) out.Imdb = any.imdb_id;
+  if (any.moviedb_id != null && !out.Tmdb) out.Tmdb = String(any.moviedb_id);
+  if (any.tmdb_id != null && !out.Tmdb) out.Tmdb = String(any.tmdb_id);
+  if (any.tvdb_id != null && !out.Tvdb) out.Tvdb = String(any.tvdb_id);
+  if (any.kitsu_id != null && !out.Kitsu) out.Kitsu = String(any.kitsu_id);
+  if (any.mal_id != null && !out.MyAnimeList)
+    out.MyAnimeList = String(any.mal_id);
+  if (any.anilist_id != null && !out.AniList)
+    out.AniList = String(any.anilist_id);
+  const ids = any.ids ?? any.externalIds;
+  if (ids && typeof ids === 'object') {
+    const rec = ids as Record<string, unknown>;
+    const map: Record<string, string> = {
+      imdb: 'Imdb',
+      imdb_id: 'Imdb',
+      tmdb: 'Tmdb',
+      tmdb_id: 'Tmdb',
+      tvdb: 'Tvdb',
+      tvdb_id: 'Tvdb',
+      kitsu: 'Kitsu',
+      mal: 'MyAnimeList',
+      anilist: 'AniList',
+      anidb: 'AniDB',
+    };
+    for (const [k, jk] of Object.entries(map)) {
+      if (rec[k] != null && !out[jk]) out[jk] = String(rec[k]);
+    }
+  }
+  return out;
+}
+
+function externalUrls(providerIds: Record<string, string>) {
+  const urls: { Name: string; Url: string }[] = [];
+  if (providerIds.Imdb)
+    urls.push({
+      Name: 'IMDb',
+      Url: `https://www.imdb.com/title/${providerIds.Imdb}`,
+    });
+  if (providerIds.Tmdb)
+    urls.push({
+      Name: 'TheMovieDb',
+      Url: `https://www.themoviedb.org/search?query=${providerIds.Tmdb}`,
+    });
+  if (providerIds.MyAnimeList)
+    urls.push({
+      Name: 'MyAnimeList',
+      Url: `https://myanimelist.net/anime/${providerIds.MyAnimeList}`,
+    });
+  if (providerIds.AniList)
+    urls.push({
+      Name: 'AniList',
+      Url: `https://anilist.co/anime/${providerIds.AniList}`,
+    });
+  if (providerIds.Kitsu)
+    urls.push({
+      Name: 'Kitsu',
+      Url: `https://kitsu.app/anime/${providerIds.Kitsu}`,
+    });
+  return urls;
+}
+
+export function defaultUserData(itemId: string): JellyfinUserItemData {
+  return {
+    PlaybackPositionTicks: 0,
+    PlayCount: 0,
+    IsFavorite: false,
+    Played: false,
+    Key: itemId,
+    ItemId: itemId,
+  };
+}
+
+export function playstateToUserData(
+  itemId: string,
+  row: JellyfinPlaystateRow | undefined,
+  runtimeTicks?: number
+): JellyfinUserItemData {
+  if (!row) return defaultUserData(itemId);
+  const rt = runtimeTicks || row.runtimeTicks;
+  const ud: JellyfinUserItemData = {
+    PlaybackPositionTicks: row.played ? 0 : row.positionTicks,
+    PlayCount: row.playCount,
+    IsFavorite: row.favorite,
+    Played: row.played,
+    Key: itemId,
+    ItemId: itemId,
+  };
+  if (row.lastPlayedAt)
+    ud.LastPlayedDate = new Date(row.lastPlayedAt).toISOString();
+  if (!row.played && rt && row.positionTicks > 0)
+    ud.PlayedPercentage = Math.min(100, (row.positionTicks / rt) * 100);
+  return ud;
+}
+
+export function stremioTypeToItemType(type: string): 'Movie' | 'Series' {
+  return type === 'movie' ? 'Movie' : 'Series';
+}
+
+export function collectionTypeFor(type: string): string | undefined {
+  if (type === 'movie') return 'movies';
+  if (type === 'series' || type === 'anime') return 'tvshows';
+  if (type === 'tv' || type === 'channel') return 'livetv';
+  return undefined;
+}
+
+function peopleFrom(meta: MetaPreview | Meta) {
+  const people: { Name: string; Id: string; Type: string; Role?: string }[] =
+    [];
+  const push = (name: string, type: string) => {
+    if (!name) return;
+    people.push({
+      Name: name,
+      Id: encodeJellyfinId({ k: 'person', n: name }),
+      Type: type,
+    });
+  };
+  const castList = Array.isArray(meta.cast)
+    ? meta.cast
+    : linksByCategory(meta, 'Cast');
+  castList.forEach((c) => push(c, 'Actor'));
+  const directors = Array.isArray(meta.director)
+    ? meta.director.filter((d): d is string => typeof d === 'string')
+    : typeof meta.director === 'string'
+      ? [meta.director]
+      : linksByCategory(meta, 'Directors');
+  directors.forEach((d) => push(d, 'Director'));
+  linksByCategory(meta, 'Writers').forEach((w) => push(w, 'Writer'));
+  return people;
+}
+
+function genresFrom(meta: MetaPreview | Meta): string[] {
+  const g =
+    Array.isArray(meta.genres) && meta.genres.length
+      ? meta.genres
+      : linksByCategory(meta, 'Genres');
+  return [
+    ...new Set(
+      g.filter((x): x is string => typeof x === 'string' && x.length > 0)
+    ),
+  ];
+}
+
+function trailersFrom(meta: MetaPreview | Meta) {
+  return (meta.trailers ?? [])
+    .filter((t) => t.source)
+    .map((t) => ({
+      Name: t.type ?? 'Trailer',
+      Url: t.source.startsWith('http')
+        ? t.source
+        : `https://www.youtube.com/watch?v=${t.source}`,
+    }));
+}
+
+export function stubMediaSources(
+  itemId: string,
+  name: string
+): JellyfinMediaSource[] {
+  return [
+    {
+      Id: itemId,
+      ETag: itemId,
+      Name: name,
+      Path: `/aiostreams/${itemId}`,
+      Protocol: 'File',
+      Type: 'Default',
+      SupportsDirectPlay: true,
+      SupportsDirectStream: true,
+      SupportsTranscoding: false,
+      MediaStreams: [],
+      Formats: [],
+    },
+    {
+      Id: streamIdToMediaSourceId(`${itemId}-stub2`),
+      ETag: itemId,
+      Name: `${name} (2)`,
+      Path: `/aiostreams/${itemId}`,
+      Protocol: 'File',
+      Type: 'Default',
+      SupportsDirectPlay: true,
+      SupportsDirectStream: true,
+      SupportsTranscoding: false,
+      MediaStreams: [],
+      Formats: [],
+    },
+  ];
+}
+
+export function buildViewItem(
+  ctx: ItemBuildContext,
+  catalog: NonNullable<Manifest['catalogs']>[number]
+): JellyfinItem {
+  const id = encodeJellyfinId({ k: 'view', t: catalog.type, c: catalog.id });
+  const collectionType = collectionTypeFor(catalog.type);
+  return {
+    Id: id,
+    Name: catalog.name,
+    ServerId: ctx.serverId,
+    Type: 'CollectionFolder',
+    IsFolder: true,
+    ...(collectionType ? { CollectionType: collectionType } : {}),
+    Etag: imageTag(`${catalog.type}:${catalog.id}`),
+    DateCreated: '2020-01-01T00:00:00.0000000Z',
+    CanDelete: false,
+    CanDownload: false,
+    SortName: catalog.name.toLowerCase(),
+    ChildCount: 0,
+    DisplayPreferencesId: id,
+    LocationType: 'FileSystem',
+    PlayAccess: 'Full',
+    ImageTags: {},
+    BackdropImageTags: [],
+    UserData: defaultUserData(id),
+    Path: `/${catalog.type}/${catalog.id}`,
+    PrimaryImageAspectRatio: 1.7777,
+    ExtraType: undefined,
+    _aio: {
+      type: catalog.type,
+      catalogId: catalog.id,
+      extras: (catalog.extra ?? []).map((e) => e.name),
+    },
+  };
+}
+
+export function stripInternal(item: JellyfinItem): JellyfinItem {
+  const { _aio, ...rest } = item as JellyfinItem & { _aio?: unknown };
+  return rest as JellyfinItem;
+}
+
+export function buildGenreItem(
+  ctx: ItemBuildContext,
+  type: string,
+  catalogId: string,
+  genre: string
+): JellyfinItem {
+  const id = encodeJellyfinId({ k: 'genre', t: type, c: catalogId, g: genre });
+  return {
+    Id: id,
+    Name: genre,
+    ServerId: ctx.serverId,
+    Type: 'Genre',
+    IsFolder: true,
+    ImageTags: {},
+    BackdropImageTags: [],
+    UserData: defaultUserData(id),
+  };
+}
+
+export function buildPersonItem(
+  ctx: ItemBuildContext,
+  name: string
+): JellyfinItem {
+  const id = encodeJellyfinId({ k: 'person', n: name });
+  return {
+    Id: id,
+    Name: name,
+    ServerId: ctx.serverId,
+    Type: 'Person',
+    IsFolder: false,
+    ImageTags: {},
+    BackdropImageTags: [],
+    UserData: defaultUserData(id),
+  };
+}
+
+export function descriptorForMeta(meta: {
+  id: string;
+  type: string;
+}): JellyfinItemDescriptor {
+  return stremioTypeToItemType(meta.type) === 'Movie'
+    ? { k: 'movie', t: meta.type, i: meta.id }
+    : { k: 'series', t: meta.type, i: meta.id };
+}
+
+export function buildMetaItem(
+  ctx: ItemBuildContext,
+  meta: MetaPreview | Meta,
+  opts: {
+    parentId?: string;
+    userData?: JellyfinPlaystateRow;
+    complete?: boolean;
+  } = {}
+): JellyfinItem {
+  const descriptor = descriptorForMeta(meta);
+  const id = encodeJellyfinId(descriptor);
+  const itemType = stremioTypeToItemType(meta.type);
+  const full = meta as Meta;
+  const providerIds = providerIdsFor(meta);
+  const genres = genresFrom(meta);
+  const runtimeTicks = parseRuntimeToTicks(full.runtime);
+  const year =
+    parseYear(meta.releaseInfo) ??
+    parseYear((meta as Record<string, unknown>).year) ??
+    parseYear((meta as Record<string, unknown>).released);
+  const premiere = toIso((meta as Record<string, unknown>).released);
+
+  const images: ItemImages = {};
+  if (meta.poster) images.Primary = meta.poster;
+  if (full.background) images.Backdrop = full.background;
+  if (full.logo) images.Logo = full.logo;
+  rememberImages(ctx.uuid, id, images, opts.complete === true);
+
+  const imageTags: Record<string, string> = {};
+  if (images.Primary) imageTags.Primary = imageTag(images.Primary);
+  if (images.Logo) imageTags.Logo = imageTag(images.Logo);
+
+  const item: JellyfinItem = {
+    Id: id,
+    Name: meta.name ?? meta.id,
+    OriginalTitle: meta.name ?? meta.id,
+    SortName: (meta.name ?? meta.id).toLowerCase(),
+    ServerId: ctx.serverId,
+    Type: itemType,
+    IsFolder: itemType === 'Series',
+    MediaType: itemType === 'Movie' ? 'Video' : undefined,
+    Etag: imageTag(id),
+    DateCreated: premiere ?? '2020-01-01T00:00:00.0000000Z',
+    CanDelete: false,
+    CanDownload: itemType === 'Movie',
+    LocationType: 'FileSystem',
+    PlayAccess: 'Full',
+    Overview: meta.description ?? undefined,
+    ProductionYear: year,
+    PremiereDate: premiere,
+    CommunityRating: numberOr(meta.imdbRating),
+    OfficialRating: (meta as Record<string, unknown>).certification as
+      | string
+      | undefined,
+    RunTimeTicks: runtimeTicks,
+    Genres: genres,
+    GenreItems: genres.map((g) => ({
+      Name: g,
+      Id: encodeJellyfinId({ k: 'genre', t: meta.type, c: '', g }),
+    })),
+    People: peopleFrom(meta),
+    Studios: [],
+    Tags: [],
+    Taglines: [],
+    ProviderIds: providerIds,
+    ExternalUrls: externalUrls(providerIds),
+    RemoteTrailers: trailersFrom(meta),
+    ImageTags: imageTags,
+    BackdropImageTags: images.Backdrop ? [imageTag(images.Backdrop)] : [],
+    ParentId: opts.parentId,
+    PrimaryImageAspectRatio:
+      meta.posterShape === 'landscape'
+        ? 1.7777
+        : meta.posterShape === 'square'
+          ? 1
+          : 0.6666,
+    VideoType: itemType === 'Movie' ? 'VideoFile' : undefined,
+    Status:
+      itemType === 'Series' ? parseReleaseStatus(meta.releaseInfo) : undefined,
+    EndDate: undefined,
+    ChildCount:
+      itemType === 'Series' ? full.videos?.length || undefined : undefined,
+    RecursiveItemCount:
+      itemType === 'Series' ? full.videos?.length || undefined : undefined,
+    UserData: playstateToUserData(id, opts.userData, runtimeTicks),
+    Path: `/${meta.type}/${meta.id}`,
+    Container: undefined,
+    MediaSources:
+      itemType === 'Movie'
+        ? stubMediaSources(id, meta.name ?? meta.id)
+        : undefined,
+    MediaStreams: undefined,
+    _aio: { descriptor },
+  };
+  if (full.language) item.PreferredMetadataLanguage = full.language;
+  if ((meta as Record<string, unknown>).country)
+    item.ProductionLocations = [
+      String((meta as Record<string, unknown>).country),
+    ];
+  if (full.website) item.HomePageUrl = full.website;
+  return item;
+}
+
+export interface SeasonGroup {
+  season: number;
+  name: string;
+  videos: NonNullable<ParsedMeta['videos']>;
+}
+
+export function groupSeasons(meta: ParsedMeta): SeasonGroup[] {
+  const videos = [...(meta.videos ?? [])];
+  if (videos.length === 0) {
+    return [
+      {
+        season: 1,
+        name: 'Season 1',
+        videos: [
+          {
+            id: meta.id,
+            title: meta.name ?? meta.id,
+            season: 1,
+            episode: 1,
+            released: (meta as Record<string, unknown>).released as
+              | string
+              | undefined,
+            thumbnail: meta.background ?? meta.poster ?? undefined,
+            overview: meta.description ?? undefined,
+          },
+        ],
+      },
+    ];
+  }
+  const numbered = videos.some((v) => typeof v.episode === 'number');
+  const groups = new Map<number, SeasonGroup>();
+  videos.forEach((v, idx) => {
+    const season = typeof v.season === 'number' ? v.season : 1;
+    if (!numbered) v.episode = idx + 1;
+    else if (typeof v.episode !== 'number') v.episode = idx + 1;
+    if (typeof v.season !== 'number') v.season = season;
+    let g = groups.get(season);
+    if (!g) {
+      g = {
+        season,
+        name: season === 0 ? 'Specials' : `Season ${season}`,
+        videos: [],
+      };
+      groups.set(season, g);
+    }
+    g.videos.push(v);
+  });
+  for (const g of groups.values()) {
+    g.videos.sort((a, b) => (a.episode ?? 0) - (b.episode ?? 0));
+  }
+  return [...groups.values()].sort((a, b) => {
+    if (a.season === 0) return 1;
+    if (b.season === 0) return -1;
+    return a.season - b.season;
+  });
+}
+
+export function buildSeasonItem(
+  ctx: ItemBuildContext,
+  meta: ParsedMeta,
+  seriesItem: JellyfinItem,
+  group: SeasonGroup,
+  playstates?: Map<string, JellyfinPlaystateRow>
+): JellyfinItem {
+  const id = encodeJellyfinId({
+    k: 'season',
+    t: meta.type,
+    i: meta.id,
+    s: group.season,
+  });
+  const images: ItemImages = {};
+  if (meta.poster) images.Primary = meta.poster;
+  if (meta.background) images.Backdrop = meta.background;
+  rememberImages(ctx.uuid, id, images, true);
+
+  let played = 0;
+  let inProgress = false;
+  if (playstates) {
+    for (const v of group.videos) {
+      const epId = encodeJellyfinId({
+        k: 'episode',
+        t: meta.type,
+        i: meta.id,
+        s: group.season,
+        e: v.episode ?? 0,
+        v: v.id,
+      });
+      const ps = playstates.get(epId);
+      if (ps?.played) played++;
+      else if (ps && ps.positionTicks > 0) inProgress = true;
+    }
+  }
+  const total = group.videos.length;
+  return {
+    Id: id,
+    Name: group.name,
+    SortName: String(group.season).padStart(4, '0'),
+    ServerId: ctx.serverId,
+    Type: 'Season',
+    IsFolder: true,
+    IndexNumber: group.season,
+    SeriesId: seriesItem.Id,
+    SeriesName: seriesItem.Name,
+    ParentId: seriesItem.Id,
+    ChildCount: total,
+    RecursiveItemCount: total,
+    LocationType: 'FileSystem',
+    PlayAccess: 'Full',
+    CanDelete: false,
+    CanDownload: false,
+    ImageTags: images.Primary ? { Primary: imageTag(images.Primary) } : {},
+    BackdropImageTags: [],
+    ParentBackdropItemId: images.Backdrop ? seriesItem.Id : undefined,
+    ParentBackdropImageTags: images.Backdrop
+      ? [imageTag(images.Backdrop)]
+      : undefined,
+    SeriesPrimaryImageTag: images.Primary
+      ? imageTag(images.Primary)
+      : undefined,
+    ParentLogoItemId: meta.logo ? seriesItem.Id : undefined,
+    ParentLogoImageTag: meta.logo ? imageTag(meta.logo) : undefined,
+    PrimaryImageAspectRatio: 0.6666,
+    ProductionYear: seriesItem.ProductionYear,
+    ProviderIds: {},
+    UserData: {
+      ...defaultUserData(id),
+      Played: total > 0 && played >= total,
+      UnplayedItemCount: Math.max(0, total - played),
+      PlayedPercentage: total > 0 ? (played / total) * 100 : 0,
+      ...(inProgress ? {} : {}),
+    },
+  };
+}
+
+export function buildEpisodeItem(
+  ctx: ItemBuildContext,
+  meta: ParsedMeta,
+  seriesItem: JellyfinItem,
+  group: SeasonGroup,
+  video: NonNullable<ParsedMeta['videos']>[number],
+  playstate?: JellyfinPlaystateRow
+): JellyfinItem {
+  const descriptor: JellyfinItemDescriptor = {
+    k: 'episode',
+    t: meta.type,
+    i: meta.id,
+    s: group.season,
+    e: video.episode ?? 0,
+    v: video.id,
+  };
+  const id = encodeJellyfinId(descriptor);
+  const seasonId = encodeJellyfinId({
+    k: 'season',
+    t: meta.type,
+    i: meta.id,
+    s: group.season,
+  });
+  const images: ItemImages = {};
+  if (video.thumbnail) images.Primary = video.thumbnail;
+  if (meta.background) images.Backdrop = meta.background;
+  rememberImages(ctx.uuid, id, images, true);
+
+  const runtimeTicks = parseRuntimeToTicks(meta.runtime);
+  const premiere = toIso(video.released);
+  const unaired = premiere ? new Date(premiere).getTime() > Date.now() : false;
+  const title = video.title ?? video.name ?? `Episode ${video.episode}`;
+
+  return {
+    Id: id,
+    Name: title,
+    SortName: `${String(group.season).padStart(4, '0')}-${String(video.episode ?? 0).padStart(4, '0')}`,
+    ServerId: ctx.serverId,
+    Type: 'Episode',
+    IsFolder: false,
+    MediaType: 'Video',
+    VideoType: 'VideoFile',
+    LocationType: unaired ? 'Virtual' : 'FileSystem',
+    PlayAccess: 'Full',
+    CanDelete: false,
+    CanDownload: !unaired,
+    IndexNumber: video.episode,
+    ParentIndexNumber: group.season,
+    SeriesId: seriesItem.Id,
+    SeriesName: seriesItem.Name,
+    SeasonId: seasonId,
+    SeasonName: group.name,
+    ParentId: seasonId,
+    Overview: video.overview ?? undefined,
+    PremiereDate: premiere,
+    ProductionYear: premiere
+      ? new Date(premiere).getUTCFullYear()
+      : seriesItem.ProductionYear,
+    RunTimeTicks: runtimeTicks,
+    ImageTags: images.Primary ? { Primary: imageTag(images.Primary) } : {},
+    BackdropImageTags: [],
+    ParentBackdropItemId: images.Backdrop ? seriesItem.Id : undefined,
+    ParentBackdropImageTags: images.Backdrop
+      ? [imageTag(images.Backdrop)]
+      : undefined,
+    SeriesPrimaryImageTag: meta.poster ? imageTag(meta.poster) : undefined,
+    ParentLogoItemId: meta.logo ? seriesItem.Id : undefined,
+    ParentLogoImageTag: meta.logo ? imageTag(meta.logo) : undefined,
+    ParentThumbItemId: images.Backdrop ? seriesItem.Id : undefined,
+    ParentThumbImageTag: images.Backdrop
+      ? imageTag(images.Backdrop)
+      : undefined,
+    PrimaryImageAspectRatio: 1.7777,
+    ProviderIds: {},
+    Genres: seriesItem.Genres,
+    CommunityRating: seriesItem.CommunityRating,
+    UserData: playstateToUserData(id, playstate, runtimeTicks),
+    MediaSources: unaired ? undefined : stubMediaSources(id, title),
+    Path: `/${meta.type}/${video.id}`,
+    _aio: { descriptor },
+  };
+}
+
+const ENCODE_TO_CODEC: Record<string, string> = {
+  AV1: 'av1',
+  HEVC: 'hevc',
+  AVC: 'h264',
+  'VC-1': 'vc1',
+  XviD: 'mpeg4',
+  DivX: 'mpeg4',
+  MPEG2: 'mpeg2video',
+};
+const AUDIO_TAG_TO_CODEC: [string, string][] = [
+  ['Atmos', 'truehd'],
+  ['TrueHD', 'truehd'],
+  ['DTS:X', 'dts'],
+  ['DTS-HD MA', 'dts'],
+  ['DTS-HD', 'dts'],
+  ['DTS-ES', 'dts'],
+  ['DTS', 'dts'],
+  ['DD+', 'eac3'],
+  ['DD', 'ac3'],
+  ['OPUS', 'opus'],
+  ['FLAC', 'flac'],
+  ['AAC', 'aac'],
+];
+const RES_TO_SIZE: Record<string, [number, number]> = {
+  '2160p': [3840, 2160],
+  '1440p': [2560, 1440],
+  '1080p': [1920, 1080],
+  '720p': [1280, 720],
+  '576p': [720, 576],
+  '480p': [640, 480],
+  '360p': [480, 360],
+  '240p': [320, 240],
+};
+
+function containerOf(stream: ParsedStream): string {
+  const ext =
+    stream.parsedFile?.container ||
+    stream.parsedFile?.extension ||
+    stream.filename?.split('.').pop() ||
+    (stream.url ? stream.url.split('?')[0].split('.').pop() : undefined);
+  const c = (ext || '').toLowerCase().replace(/^\./, '');
+  if (/^(mkv|mp4|avi|mov|m4v|ts|webm|wmv|flv|m2ts|mpg|mpeg)$/.test(c)) return c;
+  if (stream.type === 'live') return 'ts';
+  return 'mkv';
+}
+
+function channelsOf(tag: string | undefined): number | undefined {
+  if (!tag) return undefined;
+  const m = tag.match(/^(\d+)\.(\d+)$/);
+  if (!m) return undefined;
+  return Number(m[1]) + Number(m[2]);
+}
+
+export function buildMediaStreams(
+  stream: ParsedStream,
+  subtitles: { url: string; lang: string; id: string }[],
+  subtitleUrl: (
+    index: number,
+    sub: { url: string; lang: string; id: string }
+  ) => string
+): JellyfinMediaStream[] {
+  const pf = stream.parsedFile;
+  const streams: JellyfinMediaStream[] = [];
+  let index = 0;
+
+  const res =
+    pf?.resolution && pf.resolution !== 'Unknown' ? pf.resolution : undefined;
+  const size = res ? RES_TO_SIZE[res] : undefined;
+  const encode = pf?.encode && pf.encode !== 'Unknown' ? pf.encode : undefined;
+  const visual = pf?.visualTags ?? [];
+  const hasDV =
+    visual.includes('DV') ||
+    visual.includes('HDR+DV') ||
+    visual.includes('DV Only');
+  const hasHDR = visual.some(
+    (v) => /^HDR/.test(v) || v === 'HLG' || v === 'HDR Only'
+  );
+  const videoRangeType = hasDV
+    ? 'DOVI'
+    : visual.includes('HDR10+')
+      ? 'HDR10Plus'
+      : visual.includes('HDR10')
+        ? 'HDR10'
+        : visual.includes('HLG')
+          ? 'HLG'
+          : hasHDR
+            ? 'HDR10'
+            : 'SDR';
+  const videoRange = hasDV || hasHDR ? 'HDR' : 'SDR';
+  streams.push({
+    Type: 'Video',
+    Index: index++,
+    Codec: encode
+      ? (ENCODE_TO_CODEC[encode] ?? encode.toLowerCase())
+      : undefined,
+    Width: size?.[0],
+    Height: size?.[1],
+    IsDefault: true,
+    IsForced: false,
+    IsExternal: false,
+    IsInterlaced: false,
+    IsTextSubtitleStream: false,
+    SupportsExternalStream: false,
+    VideoRange: videoRange,
+    VideoRangeType: videoRangeType,
+    BitDepth: visual.includes('10bit') || hasDV || hasHDR ? 10 : 8,
+    BitRate: stream.bitrate,
+    DisplayTitle:
+      [res, encode, videoRangeType !== 'SDR' ? videoRangeType : undefined]
+        .filter(Boolean)
+        .join(' ') || 'Video',
+    Language: undefined,
+    AspectRatio: size ? (size[0] / size[1] >= 1.7 ? '16:9' : '4:3') : undefined,
+    Level: undefined,
+    Profile: undefined,
+  });
+
+  const langs = (pf?.languages ?? []).filter((l) => l && l !== 'Unknown');
+  const audioTag = (pf?.audioTags ?? []).find((t) =>
+    AUDIO_TAG_TO_CODEC.some(([k]) => k === t)
+  );
+  const audioCodec = audioTag
+    ? AUDIO_TAG_TO_CODEC.find(([k]) => k === audioTag)?.[1]
+    : undefined;
+  const channels = channelsOf(
+    (pf?.audioChannels ?? []).find((c) => c !== 'Unknown')
+  );
+  const audioLangs = langs.length ? langs : ['Unknown'];
+  audioLangs.forEach((lang, i) => {
+    const code = lang === 'Unknown' ? undefined : languageToCode(lang);
+    streams.push({
+      Type: 'Audio',
+      Index: index++,
+      Codec: audioCodec,
+      Language: code ?? (lang === 'Unknown' ? undefined : lang.toLowerCase()),
+      DisplayTitle:
+        [
+          lang !== 'Unknown' ? lang : undefined,
+          audioTag,
+          pf?.audioChannels?.[0] !== 'Unknown'
+            ? pf?.audioChannels?.[0]
+            : undefined,
+        ]
+          .filter(Boolean)
+          .join(' ') || 'Audio',
+      Channels: channels,
+      ChannelLayout:
+        channels === 6
+          ? '5.1'
+          : channels === 8
+            ? '7.1'
+            : channels === 2
+              ? 'stereo'
+              : undefined,
+      IsDefault: i === 0,
+      IsForced: false,
+      IsExternal: false,
+      IsTextSubtitleStream: false,
+      SupportsExternalStream: false,
+      BitRate: undefined,
+      SampleRate: undefined,
+    });
+  });
+
+  subtitles.forEach((sub, i) => {
+    const ext = (sub.url.split('?')[0].split('.').pop() || 'srt').toLowerCase();
+    const codec = /^(srt|vtt|ass|ssa|sub|sup)$/.test(ext)
+      ? ext === 'vtt'
+        ? 'webvtt'
+        : ext === 'sub'
+          ? 'subrip'
+          : ext
+      : 'srt';
+    const code = languageToCode(sub.lang) ?? sub.lang;
+    streams.push({
+      Type: 'Subtitle',
+      Index: index++,
+      Codec: codec === 'srt' ? 'subrip' : codec,
+      Language: code,
+      DisplayTitle: `${sub.lang} (external)`,
+      Title: sub.lang,
+      IsDefault: false,
+      IsForced: false,
+      IsExternal: true,
+      IsTextSubtitleStream: true,
+      SupportsExternalStream: true,
+      DeliveryMethod: 'External',
+      DeliveryUrl: sub.url,
+      IsExternalUrl: true,
+      Path: sub.url,
+    });
+  });
+
+  return streams;
+}
+
+export interface MediaSourceBuildOptions {
+  baseUrl: string;
+  itemId: string;
+  apiKey: string;
+  encrypt: (plain: string) => string;
+  subtitles: Subtitle[];
+  runtimeTicks?: number;
+}
+
+export function mediaSourceIdFor(stream: ParsedStream): string {
+  return streamIdToMediaSourceId(
+    stream.id || stream.url || JSON.stringify(stream.releaseKey)
+  );
+}
+
+export interface PlayableStreamRecord {
+  msid: string;
+  url: string;
+  headers?: Record<string, string>;
+  responseHeaders?: Record<string, string>;
+  filename?: string;
+  name: string;
+  type: string;
+  size?: number;
+  subtitles?: { id: string; url: string; lang: string }[];
+}
+
+export function streamToPlayable(
+  stream: ParsedStream,
+  name: string
+): PlayableStreamRecord | null {
+  if (!stream.url) return null;
+  if (
+    !stream.proxied &&
+    ((stream.requestHeaders && Object.keys(stream.requestHeaders).length) ||
+      (stream.responseHeaders && Object.keys(stream.responseHeaders).length))
+  ) {
+    return null;
+  }
+  return {
+    msid: mediaSourceIdFor(stream),
+    url: stream.url,
+    headers: stream.requestHeaders,
+    responseHeaders: stream.responseHeaders,
+    filename: stream.filename,
+    name,
+    type: stream.type,
+    size: stream.size,
+    subtitles: stream.subtitles?.map((s) => ({
+      id: s.id,
+      url: s.url,
+      lang: s.lang,
+    })),
+  };
+}
+
+export function buildMediaSource(
+  stream: ParsedStream,
+  formatted: { name: string; description: string },
+  opts: MediaSourceBuildOptions
+): JellyfinMediaSource | null {
+  if (!stream.url) return null;
+  if (
+    !stream.proxied &&
+    ((stream.requestHeaders && Object.keys(stream.requestHeaders).length) ||
+      (stream.responseHeaders && Object.keys(stream.responseHeaders).length))
+  ) {
+    return null;
+  }
+  const msid = mediaSourceIdFor(stream);
+  const container = containerOf(stream);
+  const path = stream.url;
+
+  const subs: { url: string; lang: string; id: string }[] = [
+    ...(stream.subtitles ?? []).map((s) => ({
+      url: s.url,
+      lang: s.lang,
+      id: s.id,
+    })),
+    ...opts.subtitles.map((s) => ({ url: s.url, lang: s.lang, id: s.id })),
+  ];
+  const mediaStreams = buildMediaStreams(
+    stream,
+    subs,
+    (i, sub) =>
+      `/Videos/${opts.itemId}/${msid}/Subtitles/${i}/0/Stream.${(sub.url.split('?')[0].split('.').pop() || 'srt').toLowerCase().replace(/[^a-z0-9]/g, '') || 'srt'}?api_key=${encodeURIComponent(opts.apiKey)}&u=${encodeURIComponent(opts.encrypt(sub.url))}`
+  );
+  const name = [formatted.name, formatted.description]
+    .filter(Boolean)
+    .join('\n');
+  const isLive = stream.type === 'live';
+  const subtitleIndex = mediaStreams.findIndex((s) => s.Type === 'Subtitle');
+
+  return {
+    Protocol: 'Http',
+    Id: msid,
+    Path: path,
+    DirectStreamUrl: path,
+    EncoderProtocol: undefined,
+    Type: 'Default',
+    Container: container,
+    Size: stream.size,
+    Name: name,
+    IsRemote: true,
+    ETag: msid,
+    RunTimeTicks: isLive
+      ? undefined
+      : stream.duration
+        ? stream.duration * TICKS_PER_MS
+        : opts.runtimeTicks,
+    ReadAtNativeFramerate: false,
+    IgnoreDts: false,
+    IgnoreIndex: false,
+    GenPtsInput: false,
+    SupportsTranscoding: false,
+    SupportsDirectStream: true,
+    SupportsDirectPlay: true,
+    IsInfiniteStream: isLive,
+    RequiresOpening: false,
+    RequiresClosing: false,
+    RequiresLooping: false,
+    SupportsProbing: false,
+    VideoType: 'VideoFile',
+    MediaStreams: mediaStreams,
+    MediaAttachments: [],
+    Formats: [],
+    Bitrate: stream.bitrate,
+    RequiredHttpHeaders: {},
+    DefaultAudioStreamIndex: mediaStreams.findIndex((s) => s.Type === 'Audio'),
+    DefaultSubtitleStreamIndex: -1,
+    HasSegments: false,
+  };
+}

--- a/packages/core/src/jellyfin/ids-codec.ts
+++ b/packages/core/src/jellyfin/ids-codec.ts
@@ -1,0 +1,201 @@
+import { createHash } from 'crypto';
+import type { JellyfinItemDescriptor } from '../db/repositories/jellyfin.js';
+import { IdParser } from '../utils/id-parser.js';
+
+const PACKED = 0xa1;
+const HASHED = 0xb2;
+
+const KIND_CODES: Record<string, number> = {
+  movie: 1,
+  series: 2,
+  season: 3,
+  episode: 4,
+};
+const KIND_BY_CODE = Object.fromEntries(
+  Object.entries(KIND_CODES).map(([k, v]) => [v, k])
+) as Record<number, 'movie' | 'series' | 'season' | 'episode'>;
+
+const ID_TYPE_CODES: Record<string, number> = {
+  imdbId: 1,
+  themoviedbId: 2,
+  thetvdbId: 3,
+  kitsuId: 4,
+  malId: 5,
+  anilistId: 6,
+  anidbId: 7,
+  simklId: 8,
+};
+const ID_TYPE_BY_CODE = Object.fromEntries(
+  Object.entries(ID_TYPE_CODES).map(([k, v]) => [v, k])
+);
+const ID_PREFIX_BY_TYPE: Record<string, string> = {
+  imdbId: 'tt',
+  themoviedbId: 'tmdb:',
+  thetvdbId: 'tvdb:',
+  kitsuId: 'kitsu:',
+  malId: 'mal:',
+  anilistId: 'anilist:',
+  anidbId: 'anidb:',
+  simklId: 'simkl:',
+};
+
+const MEDIA_TYPE_CODES: Record<string, number> = {
+  movie: 1,
+  series: 2,
+  anime: 3,
+  tv: 4,
+  other: 5,
+  channel: 6,
+};
+const MEDIA_TYPE_BY_CODE = Object.fromEntries(
+  Object.entries(MEDIA_TYPE_CODES).map(([k, v]) => [v, k])
+);
+
+const NONE16 = 0xffff;
+const MAX48 = 2 ** 48 - 1;
+
+function rebuildBaseId(idType: string, numeric: number): string {
+  const prefix = ID_PREFIX_BY_TYPE[idType];
+  if (idType === 'imdbId') return `tt${String(numeric).padStart(7, '0')}`;
+  return `${prefix}${numeric}`;
+}
+
+function tryPack(d: JellyfinItemDescriptor): string | null {
+  if (
+    d.k !== 'movie' &&
+    d.k !== 'series' &&
+    d.k !== 'season' &&
+    d.k !== 'episode'
+  )
+    return null;
+  const mediaCode = MEDIA_TYPE_CODES[d.t];
+  if (!mediaCode) return null;
+  const parsed = IdParser.parse(d.i, d.t);
+  if (!parsed || parsed.season || parsed.episode) return null;
+  const idTypeCode = ID_TYPE_CODES[parsed.type];
+  if (!idTypeCode) return null;
+  const rawValue = String(parsed.value);
+  const numeric = Number(
+    parsed.type === 'imdbId' ? rawValue.replace(/^tt/, '') : rawValue
+  );
+  if (!Number.isInteger(numeric) || numeric < 0 || numeric > MAX48) return null;
+  if (rebuildBaseId(parsed.type, numeric) !== d.i) return null;
+
+  let season = NONE16;
+  let episode = NONE16;
+  if (d.k === 'season') {
+    if (!Number.isInteger(d.s) || d.s < 0 || d.s >= NONE16) return null;
+    season = d.s;
+  } else if (d.k === 'episode') {
+    if (!Number.isInteger(d.s) || d.s < 0 || d.s >= NONE16) return null;
+    if (!Number.isInteger(d.e) || d.e < 0 || d.e >= NONE16) return null;
+    if (parsed.generator(parsed.value, String(d.s), String(d.e)) !== d.v)
+      return null;
+    season = d.s;
+    episode = d.e;
+  }
+
+  const buf = Buffer.alloc(16);
+  buf[0] = PACKED;
+  buf[1] = (KIND_CODES[d.k] << 4) | idTypeCode;
+  buf[2] = mediaCode;
+  buf.writeUIntBE(numeric, 3, 6);
+  buf.writeUInt16BE(season, 9);
+  buf.writeUInt16BE(episode, 11);
+  return buf.toString('hex');
+}
+
+function tryUnpack(hex: string): JellyfinItemDescriptor | null {
+  const buf = Buffer.from(hex, 'hex');
+  if (buf.length !== 16 || buf[0] !== PACKED) return null;
+  const kind = KIND_BY_CODE[buf[1] >> 4];
+  const idType = ID_TYPE_BY_CODE[buf[1] & 0x0f];
+  const mediaType = MEDIA_TYPE_BY_CODE[buf[2]];
+  if (!kind || !idType || !mediaType) return null;
+  const numeric = buf.readUIntBE(3, 6);
+  const season = buf.readUInt16BE(9);
+  const episode = buf.readUInt16BE(11);
+  const baseId = rebuildBaseId(idType, numeric);
+  switch (kind) {
+    case 'movie':
+    case 'series':
+      return { k: kind, t: mediaType, i: baseId };
+    case 'season':
+      return { k: 'season', t: mediaType, i: baseId, s: season };
+    case 'episode': {
+      const parsed = IdParser.parse(baseId, mediaType);
+      if (!parsed) return null;
+      return {
+        k: 'episode',
+        t: mediaType,
+        i: baseId,
+        s: season,
+        e: episode,
+        v: parsed.generator(parsed.value, String(season), String(episode)),
+      };
+    }
+  }
+}
+
+export function normaliseJellyfinId(id: string): string {
+  return id.replace(/-/g, '').toLowerCase();
+}
+
+export function dashedGuid(hex32: string): string {
+  return `${hex32.slice(0, 8)}-${hex32.slice(8, 12)}-${hex32.slice(12, 16)}-${hex32.slice(16, 20)}-${hex32.slice(20)}`;
+}
+
+export function canonicalDescriptor(d: JellyfinItemDescriptor): string {
+  switch (d.k) {
+    case 'view':
+      return `view|${d.t}|${d.c}`;
+    case 'genre':
+      return `genre|${d.t}|${d.c}|${d.g}`;
+    case 'movie':
+    case 'series':
+      return `${d.k}|${d.t}|${d.i}`;
+    case 'season':
+      return `season|${d.t}|${d.i}|${d.s}`;
+    case 'episode':
+      return `episode|${d.t}|${d.i}|${d.s}|${d.e}|${d.v}`;
+    case 'person':
+    case 'studio':
+      return `${d.k}|${d.n}`;
+  }
+}
+
+export function packJellyfinId(d: JellyfinItemDescriptor): string | null {
+  return tryPack(d);
+}
+
+export function unpackJellyfinId(raw: string): JellyfinItemDescriptor | null {
+  const id = normaliseJellyfinId(raw);
+  if (!/^[0-9a-f]{32}$/.test(id)) return null;
+  return tryUnpack(id);
+}
+
+export function hashJellyfinId(d: JellyfinItemDescriptor): string {
+  const hash = createHash('md5').update(canonicalDescriptor(d)).digest();
+  hash[0] = HASHED;
+  return hash.toString('hex');
+}
+
+export function isHashedJellyfinId(id: string): boolean {
+  return normaliseJellyfinId(id).slice(0, 2) === HASHED.toString(16);
+}
+
+export function uuidToJellyfinUserId(uuid: string): string {
+  return normaliseJellyfinId(uuid);
+}
+
+export function jellyfinUserIdToUuid(id: string): string {
+  return dashedGuid(normaliseJellyfinId(id));
+}
+
+export function streamIdToMediaSourceId(streamId: string): string {
+  return createHash('md5').update(streamId).digest('hex');
+}
+
+export function imageTag(url: string): string {
+  return createHash('md5').update(url).digest('hex').slice(0, 16);
+}

--- a/packages/core/src/jellyfin/ids.test.ts
+++ b/packages/core/src/jellyfin/ids.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import type { JellyfinItemDescriptor } from '../db/repositories/jellyfin.js';
 import {

--- a/packages/core/src/jellyfin/ids.test.ts
+++ b/packages/core/src/jellyfin/ids.test.ts
@@ -1,0 +1,140 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import type { JellyfinItemDescriptor } from '../db/repositories/jellyfin.js';
+import {
+  canonicalDescriptor,
+  dashedGuid,
+  hashJellyfinId,
+  normaliseJellyfinId,
+  packJellyfinId,
+  unpackJellyfinId,
+  uuidToJellyfinUserId,
+} from './ids-codec.js';
+
+const encodeJellyfinId = (d: JellyfinItemDescriptor) =>
+  packJellyfinId(d) ?? hashJellyfinId(d);
+const decodeJellyfinId = async (raw: string) => unpackJellyfinId(raw);
+
+const PACKABLE: JellyfinItemDescriptor[] = [
+  { k: 'movie', t: 'movie', i: 'tt0111161' },
+  { k: 'series', t: 'series', i: 'tt9288030' },
+  { k: 'series', t: 'anime', i: 'kitsu:1376' },
+  { k: 'movie', t: 'movie', i: 'tmdb:550' },
+  { k: 'series', t: 'series', i: 'tvdb:81189' },
+  { k: 'season', t: 'series', i: 'tt9288030', s: 2 },
+  { k: 'season', t: 'series', i: 'tt9288030', s: 0 },
+  {
+    k: 'episode',
+    t: 'series',
+    i: 'tt9288030',
+    s: 1,
+    e: 3,
+    v: 'tt9288030:1:3',
+  },
+  { k: 'episode', t: 'anime', i: 'mal:5114', s: 1, e: 13, v: 'mal:5114:13' },
+];
+
+describe('jellyfin id codec', () => {
+  it('packs standard ids into valid 32-hex GUIDs and round-trips them', async () => {
+    for (const d of PACKABLE) {
+      const id = encodeJellyfinId(d);
+      assert.match(id, /^a1[0-9a-f]{30}$/);
+      const decoded = await decodeJellyfinId(id);
+      assert.deepEqual(decoded, d);
+      const decoded2 = await decodeJellyfinId(dashedGuid(id).toUpperCase());
+      assert.deepEqual(decoded2, d);
+    }
+  });
+
+  it('is deterministic', () => {
+    const d: JellyfinItemDescriptor = {
+      k: 'movie',
+      t: 'movie',
+      i: 'tt0111161',
+    };
+    assert.deepEqual(encodeJellyfinId(d), encodeJellyfinId(d));
+  });
+
+  it('gives distinct ids to distinct descriptors', () => {
+    const ids = new Set(PACKABLE.map(encodeJellyfinId));
+    assert.equal(ids.size, PACKABLE.length);
+  });
+
+  it('falls back to hashed ids for non-numeric or exotic ids', () => {
+    const exotic: JellyfinItemDescriptor[] = [
+      {
+        k: 'movie',
+        t: 'movie',
+        i: 'aiostreams::library.realdebrid.torrent.abc',
+      },
+      { k: 'view', t: 'movie', c: 'catalog.popular' },
+      { k: 'genre', t: 'movie', c: 'catalog.popular', g: 'Action' },
+      { k: 'person', n: 'Alan Ritchson' },
+      {
+        k: 'episode',
+        t: 'series',
+        i: 'tt9288030',
+        s: 1,
+        e: 3,
+        v: 'weird-video-id',
+      },
+    ];
+    for (const d of exotic) {
+      const id = encodeJellyfinId(d);
+      assert.match(id, /^b2[0-9a-f]{30}$/);
+    }
+  });
+
+  it('keeps imdb leading zeros intact', async () => {
+    const d: JellyfinItemDescriptor = {
+      k: 'movie',
+      t: 'movie',
+      i: 'tt0000001',
+    };
+    const id = encodeJellyfinId(d);
+    assert.match(id, /^a1/);
+    assert.deepEqual(await decodeJellyfinId(id), d);
+  });
+
+  it('hashes imdb ids longer than 7 digits with leading zeros ambiguity safely', async () => {
+    const d: JellyfinItemDescriptor = {
+      k: 'movie',
+      t: 'movie',
+      i: 'tt37287335',
+    };
+    const id = encodeJellyfinId(d);
+    if (id.startsWith('a1')) {
+      assert.deepEqual(await decodeJellyfinId(id), d);
+    } else {
+      assert.match(id, /^b2/);
+    }
+  });
+
+  it('normalises and formats guids', () => {
+    const hex = 'a1210200000000d17affffffff000000';
+    assert.equal(normaliseJellyfinId(dashedGuid(hex)), hex);
+    assert.match(
+      dashedGuid(hex),
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+  });
+
+  it('maps config uuids to jellyfin user ids', () => {
+    assert.equal(
+      uuidToJellyfinUserId('01234567-89ab-cdef-0123-456789abcdef'),
+      '0123456789abcdef0123456789abcdef'
+    );
+  });
+
+  it('rejects garbage', async () => {
+    assert.equal(await decodeJellyfinId('not-a-guid'), null);
+    assert.equal(await decodeJellyfinId('a1'.padEnd(32, 'z')), null);
+  });
+
+  it('canonical descriptors are unique per field set', () => {
+    assert.notEqual(
+      canonicalDescriptor({ k: 'season', t: 'series', i: 'x', s: 1 }),
+      canonicalDescriptor({ k: 'season', t: 'series', i: 'x', s: 2 })
+    );
+  });
+});

--- a/packages/core/src/jellyfin/ids.ts
+++ b/packages/core/src/jellyfin/ids.ts
@@ -1,0 +1,80 @@
+import {
+  JellyfinRepository,
+  type JellyfinItemDescriptor,
+} from '../db/index.js';
+import { Cache } from '../utils/cache.js';
+import { createLogger } from '../logging/logger.js';
+import {
+  canonicalDescriptor,
+  hashJellyfinId,
+  isHashedJellyfinId,
+  normaliseJellyfinId,
+  packJellyfinId,
+  unpackJellyfinId,
+} from './ids-codec.js';
+
+export * from './ids-codec.js';
+
+const logger = createLogger('jellyfin');
+
+const idCache = Cache.getInstance<string, JellyfinItemDescriptor>(
+  'jellyfin-ids',
+  100_000
+);
+const ID_CACHE_TTL = 30 * 24 * 3600;
+
+const persisted = new Set<string>();
+const PERSISTED_MAX = 50_000;
+let pending: { id: string; payload: JellyfinItemDescriptor }[] = [];
+let flushTimer: NodeJS.Timeout | null = null;
+
+function scheduleFlush() {
+  if (flushTimer) return;
+  flushTimer = setTimeout(async () => {
+    flushTimer = null;
+    const batch = pending;
+    pending = [];
+    try {
+      await JellyfinRepository.rememberItems(batch);
+    } catch (e) {
+      logger.warn(
+        `Failed to persist ${batch.length} jellyfin id mappings: ${e instanceof Error ? e.message : e}`
+      );
+      for (const b of batch) persisted.delete(b.id);
+    }
+  }, 250);
+}
+
+export function encodeJellyfinId(d: JellyfinItemDescriptor): string {
+  const packed = packJellyfinId(d);
+  if (packed) return packed;
+  const id = hashJellyfinId(d);
+  if (!persisted.has(id)) {
+    if (persisted.size >= PERSISTED_MAX) persisted.clear();
+    persisted.add(id);
+    pending.push({ id, payload: d });
+    scheduleFlush();
+    void idCache.set(id, d, ID_CACHE_TTL).catch(() => undefined);
+  }
+  return id;
+}
+
+export async function decodeJellyfinId(
+  raw: string
+): Promise<JellyfinItemDescriptor | null> {
+  const id = normaliseJellyfinId(raw);
+  if (!/^[0-9a-f]{32}$/.test(id)) return null;
+  const unpacked = unpackJellyfinId(id);
+  if (unpacked) return unpacked;
+  if (!isHashedJellyfinId(id)) return null;
+  const cached = await idCache.get(id).catch(() => undefined);
+  if (cached) return cached;
+  const stored = await JellyfinRepository.lookupItem(id);
+  if (stored) {
+    void idCache.set(id, stored, ID_CACHE_TTL).catch(() => undefined);
+    return stored;
+  }
+  return null;
+}
+
+export { canonicalDescriptor };

--- a/packages/core/src/jellyfin/images.test.ts
+++ b/packages/core/src/jellyfin/images.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { Cache } from '../utils/index.js';
 import { rememberImages, recallImages } from './images.js';

--- a/packages/core/src/jellyfin/images.test.ts
+++ b/packages/core/src/jellyfin/images.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { Cache } from '../utils/index.js';
+import { rememberImages, recallImages } from './images.js';
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+describe('jellyfin image memory', () => {
+  it('does not let a catalog preview claim to be the whole answer', async () => {
+    rememberImages('u1', 'preview-item', { Primary: 'poster.jpg' });
+    await settle();
+
+    const entry = await recallImages('u1', 'preview-item');
+    assert.equal(entry?.images.Primary, 'poster.jpg');
+    assert.equal(entry?.complete, false);
+  });
+
+  it('lets a full build claim completeness', async () => {
+    rememberImages(
+      'u1',
+      'full-item',
+      { Primary: 'p', Backdrop: 'b', Logo: 'l' },
+      true
+    );
+    await settle();
+
+    const entry = await recallImages('u1', 'full-item');
+    assert.equal(entry?.complete, true);
+    assert.equal(entry?.images.Logo, 'l');
+  });
+
+  it('remembers a complete-but-empty result as a definitive "no artwork"', async () => {
+    rememberImages('u1', 'artless', {}, true);
+    await settle();
+
+    const entry = await recallImages('u1', 'artless');
+    assert.ok(entry);
+    assert.equal(entry.complete, true);
+    assert.deepEqual(entry.images, {});
+  });
+
+  it('does not write an incomplete-and-empty result, which says nothing', async () => {
+    rememberImages('u1', 'unknown', {});
+    await settle();
+
+    assert.equal(await recallImages('u1', 'unknown'), undefined);
+  });
+
+  it('scopes remembered URLs per user', async () => {
+    rememberImages('u1', 'shared-id', {
+      Primary: 'https://addon/p.jpg?key=SECRET',
+    });
+    await settle();
+
+    assert.equal(await recallImages('u2', 'shared-id'), undefined);
+  });
+
+  it('reads entries written before completeness existed as incomplete', async () => {
+    const raw = Cache.getInstance<string, unknown>('jellyfin-images', 50_000);
+    await raw.set('u1|legacy', { Primary: 'old.jpg' }, 3600);
+    await settle();
+
+    const entry = await recallImages('u1', 'legacy');
+    assert.equal(entry?.images.Primary, 'old.jpg');
+    assert.equal(entry?.complete, false);
+  });
+});

--- a/packages/core/src/jellyfin/images.ts
+++ b/packages/core/src/jellyfin/images.ts
@@ -1,0 +1,52 @@
+import { Cache } from '../utils/cache.js';
+
+export interface ItemImages {
+  Primary?: string;
+  Backdrop?: string;
+  Logo?: string;
+  Thumb?: string;
+}
+
+export interface RememberedImages {
+  images: ItemImages;
+  complete: boolean;
+}
+
+const imageCache = Cache.getInstance<string, RememberedImages>(
+  'jellyfin-images',
+  50_000
+);
+const TTL = 7 * 24 * 3600;
+const EMPTY_TTL = 10 * 60;
+
+function key(uuid: string, itemId: string): string {
+  return `${uuid}|${itemId}`;
+}
+
+function isEmpty(images: ItemImages): boolean {
+  return !images.Primary && !images.Backdrop && !images.Logo && !images.Thumb;
+}
+
+export function rememberImages(
+  uuid: string,
+  itemId: string,
+  images: ItemImages,
+  complete = false
+): void {
+  const empty = isEmpty(images);
+  if (empty && !complete) return;
+  void imageCache
+    .set(key(uuid, itemId), { images, complete }, empty ? EMPTY_TTL : TTL)
+    .catch(() => undefined);
+}
+
+export async function recallImages(
+  uuid: string,
+  itemId: string
+): Promise<RememberedImages | undefined> {
+  const entry = await imageCache.get(key(uuid, itemId)).catch(() => undefined);
+  if (!entry) return undefined;
+  if (typeof entry.complete !== 'boolean' || !entry.images)
+    return { images: entry as unknown as ItemImages, complete: false };
+  return entry;
+}

--- a/packages/core/src/jellyfin/index.ts
+++ b/packages/core/src/jellyfin/index.ts
@@ -1,0 +1,4 @@
+export * from './ids.js';
+export * from './dto.js';
+export * from './images.js';
+export * from './service.js';

--- a/packages/core/src/jellyfin/service.ts
+++ b/packages/core/src/jellyfin/service.ts
@@ -1,0 +1,345 @@
+import { AIOStreams } from '../main/index.js';
+import type {
+  Manifest,
+  MetaPreview,
+  ParsedMeta,
+  ParsedStream,
+  Subtitle,
+  UserData,
+} from '../db/schemas.js';
+import { createFormatter } from '../formatters/index.js';
+import { createLogger } from '../logging/logger.js';
+import { config as appConfig } from '../config/index.js';
+import {
+  buildMediaSource,
+  streamToPlayable,
+  type JellyfinMediaSource,
+  type MediaSourceBuildOptions,
+  type PlayableStreamRecord,
+} from './dto.js';
+
+const logger = createLogger('jellyfin');
+
+type Catalog = NonNullable<Manifest['catalogs']>[number];
+
+const STREMIO_PAGE_GUESS = 100;
+
+export interface CatalogPageOptions {
+  startIndex: number;
+  limit: number;
+  search?: string;
+  genre?: string;
+}
+
+export interface CatalogPageResult {
+  items: MetaPreview[];
+  hasMore: boolean;
+  capped: boolean;
+}
+
+export interface ResolvedStreams {
+  streams: ParsedStream[];
+  formatted: { name: string; description: string }[];
+  subtitles: Subtitle[];
+  errors: { title?: string; description?: string }[];
+}
+
+export class JellyfinService {
+  private engine: AIOStreams | null = null;
+  private initPromise: Promise<AIOStreams> | null = null;
+  private readonly metaMemo = new Map<string, Promise<ParsedMeta | null>>();
+  private readonly catalogMemo = new Map<string, Promise<MetaPreview[]>>();
+  private readonly subtitleMemo = new Map<string, Promise<Subtitle[]>>();
+  private readonly streamsMemo = new Map<string, Promise<ResolvedStreams>>();
+
+  constructor(readonly userData: UserData) {}
+
+  async getEngine(): Promise<AIOStreams> {
+    if (this.engine) return this.engine;
+    if (!this.initPromise) {
+      this.initPromise = new AIOStreams(this.userData, {
+        skipFailedAddons: true,
+      })
+        .initialise()
+        .then((e) => {
+          this.engine = e;
+          return e;
+        });
+    }
+    return this.initPromise;
+  }
+
+  async getCatalogs(): Promise<Catalog[]> {
+    const engine = await this.getEngine();
+    return (engine.getCatalogs() ?? []) as Catalog[];
+  }
+
+  async findCatalog(type: string, id: string): Promise<Catalog | undefined> {
+    const catalogs = await this.getCatalogs();
+    return catalogs.find((c) => c.type === type && c.id === id);
+  }
+
+  private fetchCatalog(
+    type: string,
+    id: string,
+    extras?: string
+  ): Promise<MetaPreview[]> {
+    const k = `${type}|${id}|${extras ?? ''}`;
+    let memo = this.catalogMemo.get(k);
+    if (!memo) {
+      memo = (async () => {
+        const engine = await this.getEngine();
+        const res = await engine.getCatalog(type, id, extras);
+        if (res.errors?.length) {
+          logger.debug(
+            { type, id, extras, errors: res.errors.length },
+            'catalog returned with errors'
+          );
+        }
+        return (res.data ?? []).filter((m) => m && m.id);
+      })();
+      this.catalogMemo.set(k, memo);
+    }
+    return memo;
+  }
+
+  async getCatalogPage(
+    catalog: Catalog,
+    opts: CatalogPageOptions
+  ): Promise<CatalogPageResult> {
+    const supports = (name: string) =>
+      (catalog.extra ?? []).some((e) => e.name === name);
+    const cap = appConfig.api.jellyfinMaxCatalogItems || Infinity;
+    const extrasBase: string[] = [];
+    if (opts.search) {
+      if (!supports('search'))
+        return { items: [], hasMore: false, capped: false };
+      extrasBase.push(`search=${opts.search}`);
+    }
+    if (opts.genre) {
+      if (!supports('genre'))
+        return { items: [], hasMore: false, capped: false };
+      extrasBase.push(`genre=${opts.genre}`);
+    }
+    const canSkip = supports('skip');
+    const wantEnd = Math.min(opts.startIndex + opts.limit, cap);
+    if (opts.startIndex >= wantEnd) {
+      return { items: [], hasMore: false, capped: opts.startIndex >= cap };
+    }
+
+    const out: MetaPreview[] = [];
+    let offset = 0;
+    let skip = 0;
+    let hasMore = true;
+    let guard = 0;
+    while (offset < wantEnd && hasMore && guard++ < 50) {
+      const extras = [...extrasBase];
+      if (skip > 0) {
+        if (!canSkip) break;
+        extras.push(`skip=${skip}`);
+      }
+      const page = await this.fetchCatalog(
+        catalog.type,
+        catalog.id,
+        extras.length ? extras.join('&') : undefined
+      );
+      if (page.length === 0) {
+        hasMore = false;
+        break;
+      }
+      for (const item of page) {
+        if (offset >= opts.startIndex && offset < wantEnd) out.push(item);
+        offset++;
+      }
+      skip += page.length;
+      if (page.length < Math.min(STREMIO_PAGE_GUESS, 20)) hasMore = false;
+      if (!canSkip) hasMore = false;
+    }
+    const capped = wantEnd < opts.startIndex + opts.limit && offset >= cap;
+    return {
+      items: out,
+      hasMore: hasMore && offset >= wantEnd && wantEnd < cap,
+      capped,
+    };
+  }
+
+  async getCatalogGenres(catalog: Catalog): Promise<string[]> {
+    const extra = (catalog.extra ?? []).find((e) => e.name === 'genre');
+    return (extra?.options ?? []).filter(
+      (o): o is string => typeof o === 'string' && o.length > 0
+    );
+  }
+
+  async search(
+    term: string,
+    types?: string[],
+    limit = 50
+  ): Promise<MetaPreview[]> {
+    const catalogs = (await this.getCatalogs()).filter(
+      (c) =>
+        (c.extra ?? []).some((e) => e.name === 'search') &&
+        (!types || types.includes(c.type))
+    );
+    const results = await Promise.allSettled(
+      catalogs.map((c) =>
+        this.getCatalogPage(c, { startIndex: 0, limit, search: term })
+      )
+    );
+    const seen = new Set<string>();
+    const out: MetaPreview[] = [];
+    for (const r of results) {
+      if (r.status !== 'fulfilled') continue;
+      for (const item of r.value.items) {
+        const k = `${item.type}|${item.id}`;
+        if (seen.has(k)) continue;
+        seen.add(k);
+        out.push(item);
+      }
+    }
+    return out.slice(0, limit);
+  }
+
+  getMeta(type: string, id: string): Promise<ParsedMeta | null> {
+    const k = `${type}|${id}`;
+    let memo = this.metaMemo.get(k);
+    if (!memo) {
+      memo = (async () => {
+        const engine = await this.getEngine();
+        const res = await engine.getMeta(type, id);
+        return res.data ?? null;
+      })();
+      this.metaMemo.set(k, memo);
+    }
+    return memo;
+  }
+
+  async getMetaLoose(type: string, id: string): Promise<ParsedMeta | null> {
+    const order =
+      type === 'anime'
+        ? [type, 'series']
+        : type === 'series'
+          ? [type, 'anime']
+          : [type];
+    for (const t of order) {
+      try {
+        const meta = await this.getMeta(t, id);
+        if (meta) return meta;
+      } catch (e) {
+        logger.debug(
+          `meta ${t}/${id} failed: ${e instanceof Error ? e.message : e}`
+        );
+      }
+    }
+    return null;
+  }
+
+  async resolveVideoId(type: string, id: string): Promise<string> {
+    const meta = await this.getMetaLoose(type, id).catch(() => null);
+    const hinted = meta?.behaviorHints?.defaultVideoId;
+    if (typeof hinted === 'string' && hinted) return hinted;
+    if (typeof meta?.id === 'string' && meta.id) return meta.id;
+    return id;
+  }
+
+  getSubtitles(type: string, videoId: string): Promise<Subtitle[]> {
+    const k = `${type}|${videoId}`;
+    let memo = this.subtitleMemo.get(k);
+    if (!memo) {
+      memo = (async () => {
+        try {
+          const engine = await this.getEngine();
+          const res = await engine.getSubtitles(type, videoId);
+          return res.data ?? [];
+        } catch (e) {
+          logger.debug(
+            `subtitles ${type}/${videoId} failed: ${e instanceof Error ? e.message : e}`
+          );
+          return [];
+        }
+      })();
+      this.subtitleMemo.set(k, memo);
+    }
+    return memo;
+  }
+
+  resolveStreams(
+    type: string,
+    videoId: string,
+    withSubtitles = true
+  ): Promise<ResolvedStreams> {
+    const k = `${type}|${videoId}|${withSubtitles ? 1 : 0}`;
+    let memo = this.streamsMemo.get(k);
+    if (!memo) {
+      memo = (async () => {
+        const engine = await this.getEngine();
+        const [response, subtitles] = await Promise.all([
+          engine.getStreams(videoId, type),
+          withSubtitles
+            ? this.getSubtitles(type, videoId)
+            : Promise.resolve([] as Subtitle[]),
+        ]);
+        const streams = response.data.streams.filter((s) => !!s.url);
+        const ctx = engine.getStreamContext();
+        const formatter = ctx
+          ? createFormatter(ctx.toFormatterContext(streams))
+          : null;
+        const formatted = await Promise.all(
+          streams.map(async (s) => {
+            if (s.addon.formatPassthrough || !formatter) {
+              return {
+                name: s.originalName || s.addon.name,
+                description: s.originalDescription || '',
+              };
+            }
+            try {
+              return await formatter.format(s);
+            } catch {
+              return {
+                name: s.originalName || s.addon.name,
+                description: s.originalDescription || '',
+              };
+            }
+          })
+        );
+        return {
+          streams,
+          formatted,
+          subtitles,
+          errors: response.errors ?? [],
+        };
+      })();
+      this.streamsMemo.set(k, memo);
+    }
+    return memo;
+  }
+
+  async resolvePlayable(
+    type: string,
+    videoId: string
+  ): Promise<PlayableStreamRecord[]> {
+    const resolved = await this.resolveStreams(type, videoId, false);
+    return resolved.streams
+      .map((s, i) => streamToPlayable(s, resolved.formatted[i].name))
+      .filter((p): p is PlayableStreamRecord => p !== null);
+  }
+
+  async buildMediaSources(
+    type: string,
+    videoId: string,
+    opts: Omit<MediaSourceBuildOptions, 'subtitles'>
+  ): Promise<{
+    sources: JellyfinMediaSource[];
+    errors: ResolvedStreams['errors'];
+  }> {
+    const resolved = await this.resolveStreams(type, videoId);
+    const sources = resolved.streams
+      .map((s, i) =>
+        buildMediaSource(s, resolved.formatted[i], {
+          ...opts,
+          subtitles: resolved.subtitles,
+        })
+      )
+      .filter((m): m is JellyfinMediaSource => m !== null);
+    return { sources, errors: resolved.errors };
+  }
+}

--- a/packages/core/src/utils/concurrency.test.ts
+++ b/packages/core/src/utils/concurrency.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { collectConcurrent } from './concurrency.js';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('collectConcurrent', () => {
+  it('keeps input order regardless of completion order', async () => {
+    const out = await collectConcurrent(
+      [50, 1, 40, 2, 30, 3],
+      async (d, i) => {
+        await sleep(d);
+        return [i];
+      },
+      { concurrency: 3 }
+    );
+    assert.deepEqual(out, [0, 1, 2, 3, 4, 5]);
+  });
+
+  it('never exceeds the configured concurrency', async () => {
+    let live = 0;
+    let peak = 0;
+    await collectConcurrent(
+      Array.from({ length: 40 }, (_, i) => i),
+      async () => {
+        live++;
+        peak = Math.max(peak, live);
+        await sleep(5);
+        live--;
+        return [1];
+      },
+      { concurrency: 4 }
+    );
+    assert.equal(peak, 4);
+  });
+
+  it('stops claiming work once the target is met', async () => {
+    let started = 0;
+    const out = await collectConcurrent(
+      Array.from({ length: 100 }, (_, i) => i),
+      async () => {
+        started++;
+        await sleep(2);
+        return [1, 1];
+      },
+      { concurrency: 4, target: 10 }
+    );
+    assert.ok(out.length >= 10);
+    assert.ok(started < 20, `started ${started}`);
+  });
+
+  it('does not let one slow item hold back the ones behind it', async () => {
+    const finished: number[] = [];
+    await collectConcurrent(
+      [200, 1, 1, 1, 1, 1],
+      async (d, i) => {
+        await sleep(d);
+        finished.push(i);
+        return [i];
+      },
+      { concurrency: 2 }
+    );
+    assert.equal(finished.at(-1), 0);
+  });
+
+  it('skips a throwing item without failing the batch', async () => {
+    const errors: string[] = [];
+    const out = await collectConcurrent(
+      [1, 2, 3, 4],
+      async (n) => {
+        if (n % 2 === 0) throw new Error(`boom ${n}`);
+        return [n];
+      },
+      { concurrency: 2, onError: (e) => errors.push((e as Error).message) }
+    );
+    assert.deepEqual(out, [1, 3]);
+    assert.deepEqual(errors, ['boom 2', 'boom 4']);
+  });
+
+  it('handles empty input and clamps a nonsensical concurrency', async () => {
+    assert.deepEqual(
+      await collectConcurrent([], async () => [1], { concurrency: 8 }),
+      []
+    );
+    assert.deepEqual(
+      await collectConcurrent([1, 2, 3], async (n) => [n], { concurrency: 0 }),
+      [1, 2, 3]
+    );
+  });
+});

--- a/packages/core/src/utils/concurrency.ts
+++ b/packages/core/src/utils/concurrency.ts
@@ -1,0 +1,33 @@
+export async function collectConcurrent<T, R>(
+  items: readonly T[],
+  fn: (item: T, index: number) => Promise<R[]>,
+  opts: {
+    concurrency: number;
+    target?: number;
+    onError?: (error: unknown, item: T, index: number) => void;
+  }
+): Promise<R[]> {
+  const concurrency = Math.max(1, Math.trunc(opts.concurrency));
+  const target = opts.target ?? Infinity;
+  const results: R[][] = items.map(() => []);
+  let cursor = 0;
+  let collected = 0;
+
+  const worker = async (): Promise<void> => {
+    while (cursor < items.length && collected < target) {
+      const index = cursor++;
+      try {
+        const batch = await fn(items[index], index);
+        results[index] = batch;
+        collected += batch.length;
+      } catch (error) {
+        opts.onError?.(error, items[index], index);
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, worker)
+  );
+  return results.flat();
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './cache.js';
+export * from './concurrency.js';
 export * from './constants.js';
 export * from './env.js';
 export * from '../logging/logger.js';

--- a/packages/frontend/src/components/menu/save-install.tsx
+++ b/packages/frontend/src/components/menu/save-install.tsx
@@ -652,9 +652,7 @@ function InstallCard({
             <AppCard
               logoSrc="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/refs/heads/master/logos/PNG-4x/jellyfin-icon--color-on-dark.png"
               name="Jellyfin"
-              description="Via Gelato plugin"
-              unofficial
-              author="lostb1t"
+              description="Connect Jellyfin apps directly"
               onClick={onOpenJellyfin}
             />
             <AppCard
@@ -2388,23 +2386,118 @@ function Content() {
           open={jellyfinModal.isOpen}
           onOpenChange={jellyfinModal.toggle}
           title="AIOStreams for Jellyfin"
-          description="Install the Gelato plugin to bring AIOStreams to Jellyfin"
+          description="Connect any Jellyfin client to this instance"
         >
           <div className="space-y-4">
             <p className="text-sm text-gray-300">
-              Gelato is an unofficial Jellyfin plugin that brings Stremio addons
-              into Jellyfin.
+              Add this instance in any Jellyfin client (Jellyfin app, Swiftfin,
+              Findroid, Streamyfin, Infuse, …) with these details:
             </p>
-            <Button
-              intent="primary"
-              className="w-full"
-              leftIcon={<FiExternalLink />}
-              onClick={() =>
-                window.open('https://github.com/lostb1t/Gelato', '_blank')
-              }
-            >
-              Open Gelato on GitHub
-            </Button>
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-gray-400 ml-1">
+                  Server address
+                </label>
+                <div className="flex items-center gap-2">
+                  <TextInput
+                    type="text"
+                    readOnly
+                    value={`${baseUrl}/jellyfin`}
+                    className="flex-1 font-mono text-sm bg-black/20"
+                    onClick={(e) => e.currentTarget.select()}
+                  />
+                  <Button
+                    onClick={() => {
+                      copyToClipboard(`${baseUrl}/jellyfin`);
+                      toast.success('Server address copied');
+                    }}
+                    intent="primary"
+                    className="shrink-0 px-3"
+                    aria-label="Copy server address"
+                  >
+                    <CopyIcon className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-gray-400 ml-1">
+                  Username
+                </label>
+                <div className="flex items-center gap-2">
+                  <TextInput
+                    type="text"
+                    readOnly
+                    value={profileAlias ?? uuid ?? ''}
+                    className="flex-1 font-mono text-sm bg-black/20"
+                    onClick={(e) => e.currentTarget.select()}
+                  />
+                  <Button
+                    onClick={() => {
+                      copyToClipboard(profileAlias ?? uuid ?? '');
+                      toast.success('Username copied');
+                    }}
+                    intent="primary"
+                    className="shrink-0 px-3"
+                    aria-label="Copy username"
+                  >
+                    <CopyIcon className="h-4 w-4" />
+                  </Button>
+                </div>
+                <p className="text-xs text-gray-500 ml-1">
+                  {profileAlias
+                    ? 'Your profile alias doubles as your Jellyfin username; the UUID also works.'
+                    : 'Your configuration UUID is your username. Sign in on this page and set a profile alias to get a friendlier one.'}
+                </p>
+              </div>
+              <p className="text-xs text-gray-500 ml-1">
+                Password: the password of this configuration. Devices without a
+                comfortable keyboard can skip the login entirely with the
+                pre-authenticated address below (treat it like a password).
+              </p>
+              {uuid && encryptedPassword && (
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-gray-400 ml-1">
+                    Pre-authenticated server address
+                  </label>
+                  <div className="flex items-center gap-2">
+                    <TextInput
+                      type="text"
+                      readOnly
+                      value={`${baseUrl}/jellyfin/${uuid}/${encryptedPassword}`}
+                      className="flex-1 font-mono text-sm bg-black/20"
+                      onClick={(e) => e.currentTarget.select()}
+                    />
+                    <Button
+                      onClick={() => {
+                        copyToClipboard(
+                          `${baseUrl}/jellyfin/${uuid}/${encryptedPassword}`
+                        );
+                        toast.success('Pre-authenticated address copied');
+                      }}
+                      intent="primary"
+                      className="shrink-0 px-3"
+                      aria-label="Copy pre-authenticated address"
+                    >
+                      <CopyIcon className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+            <p className="text-xs text-gray-500">
+              Direct play only (no transcoding) — a catalog/metadata addon (e.g.
+              TMDB or Cinemeta) fills your libraries, and a debrid or usenet
+              service makes results playable. Alternatively, the unofficial{' '}
+              <a
+                href="https://github.com/lostb1t/Gelato"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-gray-300"
+              >
+                Gelato plugin
+              </a>{' '}
+              brings Stremio addons into a real Jellyfin server.
+            </p>
           </div>
         </Modal>
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,12 +21,14 @@
     "proxy-addr": "^2.0.7",
     "rate-limit-redis": "^4.3.1",
     "undici": "^7.25.0",
+    "ws": "^8.21.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
     "@types/multer": "^2.1.0",
     "@types/node": "^20.19.39",
-    "@types/proxy-addr": "^2.0.3"
+    "@types/proxy-addr": "^2.0.3",
+    "@types/ws": "^8.18.1"
   }
 }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -30,6 +30,7 @@ import {
   addonCatalog,
   alias,
 } from './routes/stremio/index.js';
+import { createJellyfinRouter } from './routes/jellyfin/index.js';
 import {
   manifest as chillLinkManifest,
   streams as chillLinkStreams,
@@ -205,6 +206,25 @@ app.use(
   chillLinkRouter
 );
 app.use('/chilllink/:uuid/:encryptedPassword', chillLinkRouter);
+
+const jellyfinGate: express.RequestHandler = (req, res, next) => {
+  if (!appConfig.api.enableJellyfinApi) {
+    res.status(404).json({ Message: 'Jellyfin API is disabled' });
+    return;
+  }
+  next();
+};
+app.use(
+  `/jellyfin/:uuid/:encryptedPassword${VARIANT_PATH_ROUTE}`,
+  jellyfinGate,
+  createJellyfinRouter()
+);
+app.use(
+  '/jellyfin/:uuid/:encryptedPassword',
+  jellyfinGate,
+  createJellyfinRouter()
+);
+app.use('/jellyfin', jellyfinGate, createJellyfinRouter());
 
 const seanimeRouter = express.Router({ mergeParams: true });
 seanimeRouter.use(corsMiddleware);

--- a/packages/server/src/express.d.ts
+++ b/packages/server/src/express.d.ts
@@ -1,6 +1,7 @@
 import 'express';
 import { UserData, SessionUser } from '@aiostreams/core';
 import type { RateLimitInfo } from 'express-rate-limit';
+import type { JellyfinRequestContext } from './routes/jellyfin/context.js';
 
 declare global {
   namespace Express {
@@ -11,6 +12,8 @@ declare global {
       uuid?: string;
       user?: SessionUser;
       rateLimit?: RateLimitInfo;
+      jf?: JellyfinRequestContext;
+      jfLazy?: () => Promise<JellyfinRequestContext | null>;
     }
   }
 }

--- a/packages/server/src/routes/jellyfin/context.ts
+++ b/packages/server/src/routes/jellyfin/context.ts
@@ -1,0 +1,492 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+import {
+  APIError,
+  config as appConfig,
+  constants,
+  createLogger,
+  decryptString,
+  encryptString,
+  isConfigUuid,
+  isEncrypted,
+  resolveConfigAlias,
+  UserRepository,
+  validateConfig,
+  JellyfinRepository,
+  JellyfinService,
+  uuidToJellyfinUserId,
+  type UserData,
+  type ItemBuildContext,
+} from '@aiostreams/core';
+import { syncUserDataUrls } from '../../utils/syncUserData.js';
+
+const logger = createLogger('jellyfin');
+
+export const JELLYFIN_SERVER_VERSION = '10.10.7';
+export const JELLYFIN_PRODUCT_NAME = 'Jellyfin Server';
+
+export interface JellyfinRequestContext {
+  uuid: string;
+  encryptedPassword: string;
+  userData: UserData;
+  userId: string;
+  serverId: string;
+  service: JellyfinService;
+  build: ItemBuildContext;
+  baseUrl: string;
+  apiKey: string;
+  client: { name: string; device: string; deviceId: string; version: string };
+  preAuthenticated: boolean;
+}
+
+export function param(req: Request, name: string): string {
+  const v = (req.params as Record<string, string | string[] | undefined>)[name];
+  return Array.isArray(v) ? (v[0] ?? '') : (v ?? '');
+}
+
+export interface TokenPayload {
+  u: string;
+  p: string;
+  d?: string;
+}
+
+export function mintToken(payload: TokenPayload): string {
+  const res = encryptString(JSON.stringify(payload));
+  if (!res.success || !res.data) throw new Error('Failed to create token');
+  return res.data;
+}
+
+export function readToken(token: string): TokenPayload | null {
+  const res = decryptString(token);
+  if (!res.success || !res.data) return null;
+  try {
+    const parsed = JSON.parse(res.data);
+    if (parsed && typeof parsed.u === 'string' && typeof parsed.p === 'string')
+      return parsed;
+  } catch {}
+  return null;
+}
+
+export function parseMediaBrowserHeader(
+  value: string | undefined
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!value) return out;
+  const body = value.replace(/^(MediaBrowser|Emby)\s+/i, '');
+  const re = /([A-Za-z]+)\s*=\s*"([^"]*)"|([A-Za-z]+)\s*=\s*([^,\s]+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body))) {
+    const k = (m[1] ?? m[3]).toLowerCase();
+    const v = m[2] ?? m[4] ?? '';
+    out[k] = v;
+  }
+  return out;
+}
+
+export function serverIdFor(uuid: string): string {
+  return uuidToJellyfinUserId(uuid);
+}
+
+export function requestOrigin(req: Request): string {
+  const host = req.get('x-forwarded-host') || req.get('host');
+  if (host) {
+    const proto = (req.get('x-forwarded-proto') || req.protocol || 'http')
+      .split(',')[0]
+      .trim();
+    return `${proto}://${host}`;
+  }
+  if (appConfig.bootstrap.baseUrl)
+    return appConfig.bootstrap.baseUrl.replace(/\/$/, '');
+  return `http://localhost:${appConfig.bootstrap.port}`;
+}
+
+async function loadVerifiedUser(
+  uuidOrAlias: string,
+  encryptedPassword: string
+): Promise<{ uuid: string; userData: UserData } | null> {
+  let uuid = uuidOrAlias;
+  if (!isConfigUuid(uuidOrAlias)) {
+    const alias = await resolveConfigAlias(uuidOrAlias);
+    if (!alias) return null;
+    uuid = alias.uuid;
+  }
+  if (!(await UserRepository.checkUserExists(uuid))) return null;
+  const dec = decryptString(encryptedPassword);
+  if (!dec.success || dec.data == null) return null;
+  try {
+    const userData = await UserRepository.getUser(uuid, dec.data);
+    if (!userData) return null;
+    return { uuid, userData };
+  } catch (error) {
+    if (
+      error instanceof APIError &&
+      error.code === constants.ErrorCode.USER_INVALID_DETAILS
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function verifyCredentials(
+  uuidOrAlias: string,
+  encryptedPassword: string
+): Promise<string | null> {
+  let uuid = uuidOrAlias;
+  if (!isConfigUuid(uuidOrAlias)) {
+    const alias = await resolveConfigAlias(uuidOrAlias);
+    if (!alias) return null;
+    uuid = alias.uuid;
+  }
+  const dec = decryptString(encryptedPassword);
+  if (!dec.success || dec.data == null) return null;
+  return (await UserRepository.verifyCredentials(uuid, dec.data)) ? uuid : null;
+}
+
+interface CachedUser {
+  uuid: string;
+  parentUuid?: string;
+  version: string;
+  userData: UserData;
+  at: number;
+}
+const userCache = new Map<string, CachedUser>();
+const userInFlight = new Map<string, Promise<CachedUser | null>>();
+const USER_CACHE_MAX = 5_000;
+const USER_CACHE_TTL_MS = 5 * 60_000;
+
+function versionFor(
+  versions: Map<string, string>,
+  uuid: string,
+  parentUuid?: string
+): string {
+  const own = versions.get(uuid);
+  if (own == null) return '';
+  return parentUuid ? `${own}|${versions.get(parentUuid) ?? ''}` : own;
+}
+
+async function resolveUuid(uuidOrAlias: string): Promise<string | null> {
+  if (isConfigUuid(uuidOrAlias)) return uuidOrAlias;
+  const alias = await resolveConfigAlias(uuidOrAlias);
+  return alias?.uuid ?? null;
+}
+
+export async function resolveUserData(
+  uuidOrAlias: string,
+  encryptedPassword: string,
+  ip?: string
+): Promise<{ uuid: string; userData: UserData } | null> {
+  const uuid = await resolveUuid(uuidOrAlias);
+  if (!uuid) return null;
+  const key = `${uuid}|${encryptedPassword}`;
+
+  let entry = await freshCachedUser(key);
+  if (!entry) {
+    let inFlight = userInFlight.get(key);
+    if (!inFlight) {
+      inFlight = buildCachedUser(uuid, encryptedPassword).finally(() =>
+        userInFlight.delete(key)
+      );
+      userInFlight.set(key, inFlight);
+    }
+    entry = await inFlight;
+    if (!entry) return null;
+  }
+  const userData = structuredClone(entry.userData);
+  userData.ip = ip;
+  return { uuid: entry.uuid, userData };
+}
+
+async function freshCachedUser(key: string): Promise<CachedUser | null> {
+  const cached = userCache.get(key);
+  if (!cached) return null;
+  if (Date.now() - cached.at < USER_CACHE_TTL_MS) {
+    const versions = await JellyfinRepository.userVersions([
+      cached.uuid,
+      cached.parentUuid ?? '',
+    ]);
+    if (
+      versionFor(versions, cached.uuid, cached.parentUuid) === cached.version
+    ) {
+      return cached;
+    }
+  }
+  userCache.delete(key);
+  return null;
+}
+
+async function buildCachedUser(
+  uuid: string,
+  encryptedPassword: string
+): Promise<CachedUser | null> {
+  const now = Date.now();
+  const preVersions = await JellyfinRepository.userVersions([uuid]);
+  const verified = await loadVerifiedUser(uuid, encryptedPassword);
+  if (!verified) return null;
+  let userData = verified.userData;
+  userData.encryptedPassword = encryptedPassword;
+  userData.uuid = verified.uuid;
+  userData.ip = undefined;
+  userData = await syncUserDataUrls(userData);
+  userData = await validateConfig(userData, {
+    skipErrorsFromAddonsOrProxies: true,
+    decryptValues: true,
+  });
+
+  const parentUuid = verified.userData.parentConfig?.uuid || undefined;
+  const versions = parentUuid
+    ? await JellyfinRepository.userVersions([parentUuid])
+    : new Map<string, string>();
+  versions.set(uuid, preVersions.get(uuid) ?? '');
+
+  const entry: CachedUser = {
+    uuid: verified.uuid,
+    parentUuid,
+    version: versionFor(versions, uuid, parentUuid),
+    userData,
+    at: now,
+  };
+  const key = `${uuid}|${encryptedPassword}`;
+  if (userCache.size >= USER_CACHE_MAX) {
+    const oldest = userCache.keys().next().value;
+    if (oldest !== undefined) userCache.delete(oldest);
+  }
+  userCache.set(key, entry);
+  return entry;
+}
+
+function sendUnauthorized(res: Response, message = 'Unauthorized') {
+  res.status(401).json({ Message: message });
+}
+
+const PUBLIC = [
+  /^\/system\/info\/public$/i,
+  /^\/system\/ping$/i,
+  /^\/users\/authenticatebyname$/i,
+  /^\/users\/public$/i,
+  /^\/branding\/(configuration|css|css\.css)$/i,
+  /^\/quickconnect\/enabled$/i,
+  /^\/quickconnect\/initiate$/i,
+  /^\/quickconnect\/connect$/i,
+  /^\/quickconnect\/authorize$/i,
+  /^\/startup\//i,
+  /^\/system\/endpoint$/i,
+  /^\/items\/[^/]+\/images(\/|$)/i,
+  /^\/userimage$/i,
+];
+
+const LAZY_CONTEXT_PATHS = [/^\/items\/[^/]+\/images(\/|$)/i];
+
+async function buildContext(
+  req: Request,
+  uuid: string,
+  encryptedPassword: string,
+  mb: Record<string, string>,
+  reusableToken: string | undefined,
+  preAuthenticated: boolean
+): Promise<JellyfinRequestContext | null> {
+  const resolved = await resolveUserData(uuid, encryptedPassword, req.userIp);
+  if (!resolved) return null;
+  const baseUrl = `${requestOrigin(req)}${req.baseUrl}`.replace(/\/$/, '');
+  const apiKey =
+    reusableToken ??
+    mintToken({ u: resolved.uuid, p: encryptedPassword, d: mb.deviceid });
+  const serverId = serverIdFor(resolved.uuid);
+  return {
+    uuid: resolved.uuid,
+    encryptedPassword,
+    userData: resolved.userData,
+    userId: uuidToJellyfinUserId(resolved.uuid),
+    serverId,
+    service: new JellyfinService(resolved.userData),
+    build: { uuid: resolved.uuid, serverId },
+    baseUrl,
+    apiKey,
+    client: {
+      name: mb.client || 'Unknown',
+      device: mb.device || 'Unknown',
+      deviceId: mb.deviceid || 'unknown',
+      version: mb.version || '0',
+    },
+    preAuthenticated,
+  };
+}
+
+export const jellyfinContext: RequestHandler = async (req, res, next) => {
+  try {
+    const params = req.params as Record<string, string | undefined>;
+    const pathUuid = params.uuid;
+    const pathPassword = params.encryptedPassword;
+
+    const mb = parseMediaBrowserHeader(
+      req.get('authorization') ?? req.get('x-emby-authorization')
+    );
+    const token =
+      mb.token ||
+      req.get('x-emby-token') ||
+      req.get('x-mediabrowser-token') ||
+      (typeof req.query.api_key === 'string' ? req.query.api_key : undefined) ||
+      (typeof req.query.ApiKey === 'string' ? req.query.ApiKey : undefined);
+
+    let uuid: string | undefined;
+    let encryptedPassword: string | undefined;
+    let preAuthenticated = false;
+    let tokenPayload: TokenPayload | null = null;
+
+    if (token) tokenPayload = readToken(token);
+
+    if (pathUuid && pathPassword) {
+      if (!isEncrypted(pathPassword)) {
+        next('router');
+        return;
+      }
+      uuid = pathUuid;
+      encryptedPassword = pathPassword;
+      preAuthenticated = true;
+    } else if (tokenPayload) {
+      uuid = tokenPayload.u;
+      encryptedPassword = tokenPayload.p;
+    }
+
+    const isPublic = PUBLIC.some((re) => re.test(req.path));
+    if (!uuid || !encryptedPassword) {
+      if (isPublic) {
+        next();
+        return;
+      }
+      sendUnauthorized(res);
+      return;
+    }
+
+    const authedUuid = uuid;
+    const authedPassword = encryptedPassword;
+    const makeContext = () =>
+      buildContext(
+        req,
+        authedUuid,
+        authedPassword,
+        mb,
+        tokenPayload ? token : undefined,
+        preAuthenticated
+      );
+
+    if (LAZY_CONTEXT_PATHS.some((re) => re.test(req.path))) {
+      const verifiedUuid = await verifyCredentials(authedUuid, authedPassword);
+      if (!verifiedUuid) {
+        if (isPublic) {
+          next();
+          return;
+        }
+        sendUnauthorized(res, 'Invalid credentials');
+        return;
+      }
+      req.uuid = verifiedUuid;
+      let inFlight: Promise<JellyfinRequestContext | null> | null = null;
+      req.jfLazy = () => (inFlight ??= makeContext());
+      next();
+      return;
+    }
+
+    const ctx = await makeContext();
+    if (!ctx) {
+      if (isPublic) {
+        next();
+        return;
+      }
+      sendUnauthorized(res, 'Invalid credentials');
+      return;
+    }
+
+    req.jf = ctx;
+    req.userData = ctx.userData;
+    req.uuid = ctx.uuid;
+    next();
+  } catch (error) {
+    logger.error(
+      `jellyfin context error: ${error instanceof Error ? error.message : error}`
+    );
+    res.status(500).json({ Message: 'Internal error' });
+  }
+};
+
+export function requireContext(
+  req: Request,
+  res: Response
+): JellyfinRequestContext | null {
+  if (!req.jf) {
+    sendUnauthorized(res);
+    return null;
+  }
+  return req.jf;
+}
+
+export function jf(
+  handler: (
+    req: Request,
+    res: Response,
+    ctx: JellyfinRequestContext
+  ) => Promise<void> | void
+): RequestHandler {
+  return async (req, res, next: NextFunction) => {
+    if (!req.jf && req.jfLazy) {
+      try {
+        req.jf = (await req.jfLazy()) ?? undefined;
+        if (req.jf) req.userData = req.jf.userData;
+      } catch (error) {
+        logger.error(
+          {
+            path: req.originalUrl,
+            err: error instanceof Error ? error.message : String(error),
+          },
+          'jellyfin context hydration failed'
+        );
+        res.status(500).json({ Message: 'Internal error' });
+        return;
+      }
+    }
+    const ctx = requireContext(req, res);
+    if (!ctx) return;
+    try {
+      await handler(req, res, ctx);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logger.error(
+        { path: req.originalUrl, err: msg },
+        'jellyfin handler failed'
+      );
+      if (!res.headersSent) res.status(500).json({ Message: msg });
+      else next(error);
+    }
+  };
+}
+
+export function qs(req: Request, name: string): string | undefined {
+  const direct = req.query[name];
+  if (typeof direct === 'string') return direct;
+  const lower = name.toLowerCase();
+  for (const [k, v] of Object.entries(req.query)) {
+    if (k.toLowerCase() === lower && typeof v === 'string') return v;
+  }
+  return undefined;
+}
+
+export function qi(req: Request, name: string, fallback: number): number {
+  const v = qs(req, name);
+  if (v == null || v === '') return fallback;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function qb(req: Request, name: string): boolean | undefined {
+  const v = qs(req, name);
+  if (v == null) return undefined;
+  return v.toLowerCase() === 'true';
+}
+
+export function qlist(req: Request, name: string): string[] {
+  const v = qs(req, name);
+  if (!v) return [];
+  return v
+    .split(/[,|]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}

--- a/packages/server/src/routes/jellyfin/index.ts
+++ b/packages/server/src/routes/jellyfin/index.ts
@@ -1,0 +1,66 @@
+import express, { type Router } from 'express';
+import { isEncrypted } from '@aiostreams/core';
+import { corsMiddleware } from '../../middlewares/cors.js';
+import {
+  loginRateLimiter,
+  staticRateLimiter,
+  stremioCatalogRateLimiter,
+  stremioStreamRateLimiter,
+} from '../../middlewares/ratelimit.js';
+import { jellyfinContext } from './context.js';
+import systemRouter from './system.js';
+import playbackRouter from './playback.js';
+import libraryRouter from './library.js';
+
+export function createJellyfinRouter(): Router {
+  const router = express.Router({ mergeParams: true, caseSensitive: false });
+  router.use(corsMiddleware);
+  router.use(
+    express.json({
+      limit: '1mb',
+      type: ['application/json', 'text/json', 'application/*+json'],
+    })
+  );
+  router.use(express.urlencoded({ extended: false }));
+  router.use((req, _res, next) => {
+    const p = req.params as Record<string, string | undefined>;
+    if (p.uuid && p.encryptedPassword && !isEncrypted(p.encryptedPassword)) {
+      next('router');
+      return;
+    }
+    next();
+  });
+  router.use((req, _res, next) => {
+    if (/^\/emby(\/|$)/i.test(req.url))
+      req.url = req.url.replace(/^\/emby/i, '') || '/';
+    next();
+  });
+  const CATALOG_LIKE =
+    /^\/(Users\/[^/]+\/)?Items(\/Latest|\/Resume)?$|^\/UserItems\/Resume$|^\/Shows\/NextUp$|^\/Shows\/[^/]+\/(Seasons|Episodes)$|^\/Search\/Hints$|^\/Genres$/i;
+  const STREAM_LIKE = /^\/Items\/[^/]+\/(PlaybackInfo|MediaSources)$/i;
+  const LOGIN_LIKE = /^\/Users\/AuthenticateByName$/i;
+  router.use((req, res, next) => {
+    if (LOGIN_LIKE.test(req.path) && !req.params.encryptedPassword) {
+      loginRateLimiter(req, res, next);
+    } else if (STREAM_LIKE.test(req.path)) {
+      stremioStreamRateLimiter(req, res, next);
+    } else if (CATALOG_LIKE.test(req.path)) {
+      stremioCatalogRateLimiter(req, res, next);
+    } else {
+      staticRateLimiter(req, res, next);
+    }
+  });
+  router.use(jellyfinContext);
+  router.use(systemRouter);
+  router.use(playbackRouter);
+  router.use(libraryRouter);
+  router.use((req, res) => {
+    res.status(404).json({
+      Message: `Unsupported Jellyfin endpoint: ${req.method} ${req.path}`,
+    });
+  });
+  return router;
+}
+
+export { attachJellyfinWebSocket } from './ws.js';
+export { registerJellyfinTasks } from './tasks.js';

--- a/packages/server/src/routes/jellyfin/items.ts
+++ b/packages/server/src/routes/jellyfin/items.ts
@@ -1,0 +1,310 @@
+import {
+  buildEpisodeItem,
+  buildMetaItem,
+  buildSeasonItem,
+  buildViewItem,
+  buildGenreItem,
+  buildPersonItem,
+  decodeJellyfinId,
+  encodeJellyfinId,
+  groupSeasons,
+  JellyfinRepository,
+  playstateToUserData,
+  stripInternal,
+  type JellyfinItem,
+  type JellyfinItemDescriptor,
+  type JellyfinPlaystateRow,
+  type MetaPreview,
+  type ParsedMeta,
+} from '@aiostreams/core';
+import type { JellyfinRequestContext } from './context.js';
+
+export interface ItemList {
+  Items: JellyfinItem[];
+  TotalRecordCount: number;
+  StartIndex: number;
+}
+
+export function list(
+  items: JellyfinItem[],
+  total?: number,
+  startIndex = 0
+): ItemList {
+  return {
+    Items: items.map(stripInternal),
+    TotalRecordCount: total ?? startIndex + items.length,
+    StartIndex: startIndex,
+  };
+}
+
+export async function attachUserData(
+  ctx: JellyfinRequestContext,
+  items: JellyfinItem[]
+): Promise<JellyfinItem[]> {
+  const ids = items
+    .filter(
+      (i) => i.Type === 'Movie' || i.Type === 'Episode' || i.Type === 'Series'
+    )
+    .map((i) => i.Id);
+  if (!ids.length) return items;
+  const states = await JellyfinRepository.getPlaystates(ctx.uuid, ids);
+  if (!states.size) return items;
+  for (const item of items) {
+    const ps = states.get(item.Id);
+    if (!ps) continue;
+    if (item.Type === 'Series') {
+      item.UserData = { ...(item.UserData as object), IsFavorite: ps.favorite };
+    } else {
+      item.UserData = playstateToUserData(
+        item.Id,
+        ps,
+        item.RunTimeTicks as number | undefined
+      );
+    }
+  }
+  return items;
+}
+
+export async function itemsFromPreviews(
+  ctx: JellyfinRequestContext,
+  previews: MetaPreview[],
+  parentId?: string
+): Promise<JellyfinItem[]> {
+  const items = previews.map((p) => buildMetaItem(ctx.build, p, { parentId }));
+  return attachUserData(ctx, items);
+}
+
+export async function viewItems(
+  ctx: JellyfinRequestContext
+): Promise<JellyfinItem[]> {
+  const catalogs = await ctx.service.getCatalogs();
+  return catalogs.map((c) => buildViewItem(ctx.build, c));
+}
+
+export async function findView(
+  ctx: JellyfinRequestContext,
+  d: { t: string; c: string }
+) {
+  return ctx.service.findCatalog(d.t, d.c);
+}
+
+export function findEpisode(
+  meta: ParsedMeta,
+  d: Extract<JellyfinItemDescriptor, { k: 'episode' }>
+) {
+  const groups = groupSeasons(meta);
+  for (const g of groups) {
+    for (const v of g.videos) {
+      if (v.id === d.v) return { group: g, video: v };
+    }
+  }
+  for (const g of groups) {
+    if (g.season !== d.s) continue;
+    const v = g.videos.find((x) => x.episode === d.e);
+    if (v) return { group: g, video: v };
+  }
+  return null;
+}
+
+export async function itemFromDescriptor(
+  ctx: JellyfinRequestContext,
+  d: JellyfinItemDescriptor,
+  opts: { playstate?: JellyfinPlaystateRow; seriesPlaystates?: boolean } = {}
+): Promise<JellyfinItem | null> {
+  switch (d.k) {
+    case 'view': {
+      const catalog = await findView(ctx, d);
+      return catalog ? buildViewItem(ctx.build, catalog) : null;
+    }
+    case 'genre':
+      return buildGenreItem(ctx.build, d.t, d.c, d.g);
+    case 'person':
+      return buildPersonItem(ctx.build, d.n);
+    case 'studio':
+      return {
+        Id: encodeJellyfinId(d),
+        Name: d.n,
+        ServerId: ctx.serverId,
+        Type: 'Studio',
+        IsFolder: true,
+      };
+    case 'movie':
+    case 'series': {
+      const meta = await ctx.service.getMetaLoose(d.t, d.i);
+      const base = meta
+        ? { ...meta, id: d.i }
+        : ({ id: d.i, type: d.t, name: d.i } as MetaPreview);
+      const item = buildMetaItem(
+        ctx.build,
+        { ...base, type: d.t },
+        { userData: opts.playstate, complete: !!meta }
+      );
+      if (!opts.playstate) await attachUserData(ctx, [item]);
+      return item;
+    }
+    case 'season': {
+      const meta = await ctx.service.getMetaLoose(d.t, d.i);
+      if (!meta) return null;
+      const seriesItem = buildMetaItem(
+        ctx.build,
+        { ...meta, type: d.t },
+        { complete: true }
+      );
+      const group = groupSeasons(meta).find((g) => g.season === d.s);
+      if (!group) return null;
+      const states = await JellyfinRepository.getPlaystates(
+        ctx.uuid,
+        group.videos.map((v) =>
+          encodeJellyfinId({
+            k: 'episode',
+            t: d.t,
+            i: d.i,
+            s: group.season,
+            e: v.episode ?? 0,
+            v: v.id,
+          })
+        )
+      );
+      return buildSeasonItem(ctx.build, meta, seriesItem, group, states);
+    }
+    case 'episode': {
+      const meta = await ctx.service.getMetaLoose(d.t, d.i);
+      if (!meta) return null;
+      const seriesItem = buildMetaItem(
+        ctx.build,
+        { ...meta, type: d.t },
+        { complete: true }
+      );
+      const found = findEpisode(meta, d);
+      const group = found?.group ?? {
+        season: d.s,
+        name: d.s === 0 ? 'Specials' : `Season ${d.s}`,
+        videos: [],
+      };
+      const video = found?.video ?? {
+        id: d.v,
+        title: `Episode ${d.e}`,
+        season: d.s,
+        episode: d.e,
+      };
+      const ps =
+        opts.playstate ??
+        (await JellyfinRepository.getPlaystate(
+          ctx.uuid,
+          encodeJellyfinId(d)
+        )) ??
+        undefined;
+      return buildEpisodeItem(ctx.build, meta, seriesItem, group, video, ps);
+    }
+  }
+}
+
+export async function itemFromId(
+  ctx: JellyfinRequestContext,
+  id: string
+): Promise<{ item: JellyfinItem; descriptor: JellyfinItemDescriptor } | null> {
+  const d = await decodeJellyfinId(id);
+  if (!d) return null;
+  const item = await itemFromDescriptor(ctx, d);
+  return item ? { item, descriptor: d } : null;
+}
+
+export async function seasonsForSeries(
+  ctx: JellyfinRequestContext,
+  d: { t: string; i: string }
+): Promise<{
+  meta: ParsedMeta;
+  seriesItem: JellyfinItem;
+  seasons: JellyfinItem[];
+} | null> {
+  const meta = await ctx.service.getMetaLoose(d.t, d.i);
+  if (!meta) return null;
+  const seriesItem = buildMetaItem(
+    ctx.build,
+    { ...meta, type: d.t },
+    { complete: true }
+  );
+  const groups = groupSeasons(meta);
+  const allEpisodeIds = groups.flatMap((g) =>
+    g.videos.map((v) =>
+      encodeJellyfinId({
+        k: 'episode',
+        t: d.t,
+        i: d.i,
+        s: g.season,
+        e: v.episode ?? 0,
+        v: v.id,
+      })
+    )
+  );
+  const states = await JellyfinRepository.getPlaystates(
+    ctx.uuid,
+    allEpisodeIds
+  );
+  const seasons = groups.map((g) =>
+    buildSeasonItem(ctx.build, meta, seriesItem, g, states)
+  );
+  return { meta, seriesItem, seasons };
+}
+
+export async function episodesForSeries(
+  ctx: JellyfinRequestContext,
+  d: { t: string; i: string },
+  season?: number
+): Promise<{
+  meta: ParsedMeta;
+  seriesItem: JellyfinItem;
+  episodes: JellyfinItem[];
+} | null> {
+  const meta = await ctx.service.getMetaLoose(d.t, d.i);
+  if (!meta) return null;
+  const seriesItem = buildMetaItem(
+    ctx.build,
+    { ...meta, type: d.t },
+    { complete: true }
+  );
+  const groups = groupSeasons(meta).filter(
+    (g) => season == null || g.season === season
+  );
+  const pairs = groups.flatMap((g) => g.videos.map((v) => ({ g, v })));
+  const ids = pairs.map(({ g, v }) =>
+    encodeJellyfinId({
+      k: 'episode',
+      t: d.t,
+      i: d.i,
+      s: g.season,
+      e: v.episode ?? 0,
+      v: v.id,
+    })
+  );
+  const states = await JellyfinRepository.getPlaystates(ctx.uuid, ids);
+  const episodes = pairs.map(({ g, v }, idx) =>
+    buildEpisodeItem(ctx.build, meta, seriesItem, g, v, states.get(ids[idx]))
+  );
+  return { meta, seriesItem, episodes };
+}
+
+export async function nextUpForSeries(
+  ctx: JellyfinRequestContext,
+  d: { t: string; i: string },
+  last?: JellyfinPlaystateRow
+): Promise<JellyfinItem | null> {
+  const res = await episodesForSeries(ctx, d);
+  if (!res) return null;
+  const eps = res.episodes.filter(
+    (e) => e.LocationType !== 'Virtual' && (e.ParentIndexNumber as number) !== 0
+  );
+  if (!eps.length) return null;
+  if (last) {
+    const idx = eps.findIndex((e) => e.Id === last.itemId);
+    if (idx >= 0) {
+      const lastUd = eps[idx].UserData as {
+        Played: boolean;
+        PlaybackPositionTicks: number;
+      };
+      if (!lastUd.Played && lastUd.PlaybackPositionTicks > 0) return eps[idx];
+      return eps[idx + 1] ?? null;
+    }
+  }
+  return eps.find((e) => !(e.UserData as { Played: boolean }).Played) ?? null;
+}

--- a/packages/server/src/routes/jellyfin/library.ts
+++ b/packages/server/src/routes/jellyfin/library.ts
@@ -1,0 +1,1016 @@
+import { Router, type Request } from 'express';
+import {
+  collectConcurrent,
+  config as appConfig,
+  createLogger,
+  encryptString,
+} from '@aiostreams/core';
+import {
+  buildGenreItem,
+  buildMetaItem,
+  buildViewItem,
+  decodeJellyfinId,
+  encodeJellyfinId,
+  JellyfinRepository,
+  stripInternal,
+  collectionTypeFor,
+  type JellyfinItem,
+  type JellyfinItemDescriptor,
+  type MetaPreview,
+} from '@aiostreams/core';
+import {
+  jf,
+  qb,
+  qi,
+  qlist,
+  qs,
+  type JellyfinRequestContext,
+  param,
+} from './context.js';
+import {
+  attachUserData,
+  episodesForSeries,
+  itemFromDescriptor,
+  itemFromId,
+  itemsFromPreviews,
+  list,
+  nextUpForSeries,
+  seasonsForSeries,
+  viewItems,
+} from './items.js';
+
+const logger = createLogger('jellyfin');
+const router: Router = Router({ mergeParams: true });
+
+const MAX_MEDIA_SOURCES = 50;
+
+function lookup<T, R>(
+  items: readonly T[],
+  fn: (item: T) => Promise<R[]>,
+  opts: { target?: number; what: string }
+): Promise<R[]> {
+  return collectConcurrent(items, fn, {
+    concurrency: appConfig.api.jellyfinLookupConcurrency,
+    target: opts.target,
+    onError: (error) =>
+      logger.debug(
+        { err: error instanceof Error ? error.message : String(error) },
+        `skipping unresolvable ${opts.what}`
+      ),
+  });
+}
+
+function encryptToken(plain: string): string {
+  const r = encryptString(plain);
+  if (!r.success || !r.data) throw new Error('encryption failed');
+  return r.data;
+}
+
+async function views(ctx: JellyfinRequestContext) {
+  const items = await viewItems(ctx);
+  return list(items, items.length);
+}
+
+router.get(
+  ['/Users/:userId/Views', '/UserViews'],
+  jf(async (_req, res, ctx) => {
+    res.json(await views(ctx));
+  })
+);
+router.get(
+  ['/Users/:userId/GroupingOptions', '/UserViews/GroupingOptions'],
+  jf(async (_req, res, ctx) => {
+    const items = await viewItems(ctx);
+    res.json(items.map((i) => ({ Name: i.Name, Id: i.Id })));
+  })
+);
+router.get(
+  ['/Library/VirtualFolders', '/Library/MediaFolders'],
+  jf(async (req, res, ctx) => {
+    const items = await viewItems(ctx);
+    if (/MediaFolders/i.test(req.path)) {
+      res.json(list(items, items.length));
+      return;
+    }
+    res.json(
+      items.map((i) => ({
+        Name: i.Name,
+        Locations: [i.Path],
+        CollectionType: i.CollectionType ?? null,
+        LibraryOptions: {
+          Enabled: true,
+          EnableRealtimeMonitor: false,
+          PathInfos: [],
+        },
+        ItemId: i.Id,
+        PrimaryImageItemId: i.Id,
+        RefreshStatus: 'Idle',
+      }))
+    );
+  })
+);
+
+type ItemTypeFilter = Set<string> | null;
+
+function includeTypes(req: Request): ItemTypeFilter {
+  const types = qlist(req, 'IncludeItemTypes');
+  return types.length ? new Set(types.map((t) => t.toLowerCase())) : null;
+}
+
+function filterByType(
+  items: JellyfinItem[],
+  types: ItemTypeFilter
+): JellyfinItem[] {
+  if (!types) return items;
+  return items.filter((i) => types.has(String(i.Type).toLowerCase()));
+}
+
+function stremioTypesFor(types: ItemTypeFilter): string[] | undefined {
+  if (!types) return undefined;
+  const out = new Set<string>();
+  if (types.has('movie')) out.add('movie');
+  if (types.has('series') || types.has('episode') || types.has('season')) {
+    out.add('series');
+    out.add('anime');
+  }
+  return out.size ? [...out] : undefined;
+}
+
+function applyUserFilters(req: Request, items: JellyfinItem[]): JellyfinItem[] {
+  const filters = qlist(req, 'Filters').map((f) => f.toLowerCase());
+  const isPlayed = qb(req, 'IsPlayed');
+  const isFavorite = qb(req, 'IsFavorite');
+  let out = items;
+  const ud = (i: JellyfinItem) =>
+    i.UserData as {
+      Played: boolean;
+      IsFavorite: boolean;
+      PlaybackPositionTicks: number;
+    };
+  if (filters.includes('isplayed') || isPlayed === true)
+    out = out.filter((i) => ud(i).Played);
+  if (filters.includes('isunplayed') || isPlayed === false)
+    out = out.filter((i) => !ud(i).Played);
+  if (filters.includes('isfavorite') || isFavorite === true)
+    out = out.filter((i) => ud(i).IsFavorite);
+  if (filters.includes('isresumable'))
+    out = out.filter((i) => ud(i).PlaybackPositionTicks > 0);
+  return out;
+}
+
+function applySort(req: Request, items: JellyfinItem[]): JellyfinItem[] {
+  const sortBy = qlist(req, 'SortBy').map((s) => s.toLowerCase());
+  const desc = (qs(req, 'SortOrder') ?? '').toLowerCase() === 'descending';
+  if (!sortBy.length || sortBy[0] === 'default') return items;
+  const key = sortBy[0];
+  const val = (i: JellyfinItem): number | string => {
+    switch (key) {
+      case 'sortname':
+      case 'name':
+        return String(i.SortName ?? i.Name ?? '').toLowerCase();
+      case 'productionyear':
+      case 'premieredate':
+        return Number(i.ProductionYear ?? 0);
+      case 'communityrating':
+        return Number(i.CommunityRating ?? 0);
+      case 'runtime':
+        return Number(i.RunTimeTicks ?? 0);
+      case 'random':
+        return Math.random();
+      case 'datecreated':
+      case 'dateplayed':
+      case 'dateadded':
+      default:
+        return 0;
+    }
+  };
+  if (
+    ['datecreated', 'dateplayed', 'dateadded', 'datelastcontentadded'].includes(
+      key
+    )
+  )
+    return items;
+  const sorted = [...items].sort((a, b) => {
+    const av = val(a);
+    const bv = val(b);
+    if (av < bv) return -1;
+    if (av > bv) return 1;
+    return 0;
+  });
+  return desc ? sorted.reverse() : sorted;
+}
+
+async function itemsFromPlaystates(
+  ctx: JellyfinRequestContext,
+  rows: Awaited<ReturnType<typeof JellyfinRepository.listFavorites>>,
+  limit: number
+): Promise<JellyfinItem[]> {
+  return lookup(
+    rows.slice(0, limit),
+    async (row) => {
+      const item = await itemFromDescriptor(ctx, row.payload, {
+        playstate: row,
+      });
+      return item ? [item] : [];
+    },
+    { what: 'item' }
+  );
+}
+
+async function handleItemsQuery(req: Request, ctx: JellyfinRequestContext) {
+  const startIndex = Math.max(0, qi(req, 'StartIndex', 0));
+  const limit = Math.min(Math.max(1, qi(req, 'Limit', 100)), 500);
+  const parentId = qs(req, 'ParentId');
+  const ids = qlist(req, 'Ids');
+  const searchTerm = qs(req, 'SearchTerm')?.trim();
+  const types = includeTypes(req);
+  const genres = qlist(req, 'Genres');
+  const genreIds = qlist(req, 'GenreIds');
+  const filters = qlist(req, 'Filters').map((f) => f.toLowerCase());
+  const wantsFavorites =
+    filters.includes('isfavorite') || qb(req, 'IsFavorite') === true;
+  const wantsPlayed =
+    filters.includes('isplayed') || qb(req, 'IsPlayed') === true;
+  const wantsResumable = filters.includes('isresumable');
+  const recursive = qb(req, 'Recursive') ?? false;
+  const personIds = qlist(req, 'PersonIds');
+
+  if (ids.length) {
+    const items = await lookup(
+      ids.slice(0, 200),
+      async (id) => {
+        const r = await itemFromId(ctx, id);
+        return r ? [r.item] : [];
+      },
+      { what: 'id' }
+    );
+    return list(filterByType(items, types), items.length, 0);
+  }
+
+  let parent: JellyfinItemDescriptor | null = null;
+  if (parentId) parent = await decodeJellyfinId(parentId);
+
+  if (parent?.k === 'series') {
+    if (types?.has('episode') || recursive) {
+      const r = await episodesForSeries(ctx, parent);
+      const eps = applyUserFilters(req, r?.episodes ?? []);
+      return list(
+        filterByType(eps, types ?? new Set(['episode'])).slice(
+          startIndex,
+          startIndex + limit
+        ),
+        eps.length,
+        startIndex
+      );
+    }
+    const r = await seasonsForSeries(ctx, parent);
+    const seasons = r?.seasons ?? [];
+    return list(
+      seasons.slice(startIndex, startIndex + limit),
+      seasons.length,
+      startIndex
+    );
+  }
+  if (parent?.k === 'season') {
+    const r = await episodesForSeries(ctx, parent, parent.s);
+    const eps = applyUserFilters(req, r?.episodes ?? []);
+    return list(
+      eps.slice(startIndex, startIndex + limit),
+      eps.length,
+      startIndex
+    );
+  }
+  if (parent?.k === 'person' || personIds.length) {
+    const name = parent?.k === 'person' ? parent.n : null;
+    const previews = name
+      ? await ctx.service.search(name, stremioTypesFor(types), limit)
+      : [];
+    const items = await itemsFromPreviews(ctx, previews);
+    return list(filterByType(items, types), items.length, 0);
+  }
+
+  if (wantsFavorites || wantsPlayed || wantsResumable) {
+    const kinds = types
+      ? [...types].map((t) =>
+          t === 'movie'
+            ? 'movie'
+            : t === 'episode'
+              ? 'episode'
+              : t === 'series'
+                ? 'series'
+                : t
+        )
+      : undefined;
+    const rows = wantsFavorites
+      ? await JellyfinRepository.listFavorites(ctx.uuid, kinds)
+      : wantsResumable
+        ? await JellyfinRepository.listResume(ctx.uuid, limit + startIndex)
+        : await JellyfinRepository.listPlayed(ctx.uuid, kinds);
+    const items = await itemsFromPlaystates(ctx, rows, startIndex + limit);
+    const page = applySort(req, filterByType(items, types)).slice(
+      startIndex,
+      startIndex + limit
+    );
+    return list(page, items.length, startIndex);
+  }
+
+  const genreFromIds = genreIds.length
+    ? await decodeJellyfinId(genreIds[0])
+    : null;
+  const genre =
+    genres[0] ?? (genreFromIds?.k === 'genre' ? genreFromIds.g : undefined);
+
+  let catalogDesc: { t: string; c: string } | null = null;
+  if (parent?.k === 'view') catalogDesc = parent;
+  else if (parent?.k === 'genre') catalogDesc = parent;
+  else if (genreFromIds?.k === 'genre' && genreFromIds.c)
+    catalogDesc = genreFromIds;
+
+  if (catalogDesc) {
+    const catalog = await ctx.service.findCatalog(catalogDesc.t, catalogDesc.c);
+    if (!catalog) return list([], 0, startIndex);
+    const g = parent?.k === 'genre' ? parent.g : genre;
+    const page = await ctx.service.getCatalogPage(catalog, {
+      startIndex,
+      limit,
+      search: searchTerm,
+      genre: g,
+    });
+    const items = await itemsFromPreviews(ctx, page.items, parentId);
+    const filtered = applySort(
+      req,
+      applyUserFilters(req, filterByType(items, types))
+    );
+    const total = page.hasMore
+      ? startIndex + filtered.length + limit
+      : startIndex + filtered.length;
+    return list(filtered, total, startIndex);
+  }
+
+  if (searchTerm) {
+    const previews = await ctx.service.search(
+      searchTerm,
+      stremioTypesFor(types),
+      startIndex + limit
+    );
+    const items = await itemsFromPreviews(ctx, previews);
+    const filtered = filterByType(items, types);
+    return list(
+      filtered.slice(startIndex, startIndex + limit),
+      filtered.length,
+      startIndex
+    );
+  }
+
+  if (!parentId && !recursive) {
+    return views(ctx);
+  }
+
+  if (!parentId && recursive) {
+    const catalogs = await ctx.service.getCatalogs();
+    const wanted = stremioTypesFor(types);
+    const usable = catalogs.filter((c) => !wanted || wanted.includes(c.type));
+    const items: JellyfinItem[] = [];
+    let offset = 0;
+    for (const catalog of usable) {
+      if (items.length >= limit) break;
+      const page = await ctx.service.getCatalogPage(catalog, {
+        startIndex: Math.max(0, startIndex - offset),
+        limit: limit - items.length + Math.max(0, offset - startIndex),
+      });
+      const viewId = encodeJellyfinId({
+        k: 'view',
+        t: catalog.type,
+        c: catalog.id,
+      });
+      const built = await itemsFromPreviews(ctx, page.items, viewId);
+      for (const it of built) {
+        if (offset >= startIndex && items.length < limit) items.push(it);
+        offset++;
+      }
+      if (page.hasMore) offset += 1;
+      if (page.hasMore && items.length >= limit) {
+        return list(
+          filterByType(items, types),
+          startIndex + items.length + limit,
+          startIndex
+        );
+      }
+    }
+    return list(
+      filterByType(items, types),
+      startIndex + items.length,
+      startIndex
+    );
+  }
+
+  return list([], 0, startIndex);
+}
+
+router.get(
+  ['/Users/:userId/Items', '/Items'],
+  jf(async (req, res, ctx) => {
+    res.json(await handleItemsQuery(req, ctx));
+  })
+);
+
+router.get(
+  ['/Users/:userId/Items/Latest', '/Items/Latest'],
+  jf(async (req, res, ctx) => {
+    const limit = Math.min(Math.max(1, qi(req, 'Limit', 16)), 100);
+    const parentId = qs(req, 'ParentId');
+    const types = includeTypes(req);
+    let items: JellyfinItem[] = [];
+    if (parentId) {
+      const d = await decodeJellyfinId(parentId);
+      if (d?.k === 'view') {
+        const catalog = await ctx.service.findCatalog(d.t, d.c);
+        if (catalog) {
+          const page = await ctx.service.getCatalogPage(catalog, {
+            startIndex: 0,
+            limit,
+          });
+          items = await itemsFromPreviews(ctx, page.items, parentId);
+        }
+      }
+    } else {
+      const catalogs = await ctx.service.getCatalogs();
+      const wanted = stremioTypesFor(types);
+      const usable = catalogs.filter((c) => !wanted || wanted.includes(c.type));
+      const perCatalog = Math.max(
+        4,
+        Math.ceil(limit / Math.max(1, usable.length))
+      );
+      items = await lookup(
+        usable,
+        async (catalog) => {
+          const page = await ctx.service.getCatalogPage(catalog, {
+            startIndex: 0,
+            limit: perCatalog,
+          });
+          const built = await itemsFromPreviews(
+            ctx,
+            page.items,
+            encodeJellyfinId({ k: 'view', t: catalog.type, c: catalog.id })
+          );
+          return filterByType(built, types);
+        },
+        { target: limit, what: 'catalog in Latest' }
+      );
+    }
+    res.json(filterByType(items, types).slice(0, limit).map(stripInternal));
+  })
+);
+
+router.get(
+  ['/Users/:userId/Items/Resume', '/UserItems/Resume'],
+  jf(async (req, res, ctx) => {
+    const limit = Math.min(Math.max(1, qi(req, 'Limit', 12)), 100);
+    const startIndex = Math.max(0, qi(req, 'StartIndex', 0));
+    const types = includeTypes(req);
+    const mediaTypes = qlist(req, 'MediaTypes').map((m) => m.toLowerCase());
+    if (mediaTypes.length && !mediaTypes.includes('video')) {
+      res.json(list([], 0, startIndex));
+      return;
+    }
+    const kinds = types
+      ? [...types].filter((t) => t === 'movie' || t === 'episode')
+      : ['movie', 'episode'];
+    const rows = await JellyfinRepository.listResume(
+      ctx.uuid,
+      startIndex + limit,
+      kinds.length ? kinds : ['movie', 'episode']
+    );
+    const items = await itemsFromPlaystates(ctx, rows, startIndex + limit);
+    res.json(
+      list(
+        items.slice(startIndex, startIndex + limit),
+        items.length,
+        startIndex
+      )
+    );
+  })
+);
+
+router.get(
+  '/Shows/NextUp',
+  jf(async (req, res, ctx) => {
+    const limit = Math.min(Math.max(1, qi(req, 'Limit', 12)), 50);
+    const seriesId = qs(req, 'SeriesId');
+    const items: JellyfinItem[] = [];
+    if (seriesId) {
+      const d = await decodeJellyfinId(seriesId);
+      if (d && (d.k === 'series' || d.k === 'movie')) {
+        const rows = await JellyfinRepository.listForSeries(ctx.uuid, d.t, d.i);
+        rows.sort((a, b) => b.updatedAt - a.updatedAt);
+        const next = await nextUpForSeries(ctx, d, rows[0]);
+        if (next) items.push(next);
+      }
+    } else {
+      const recent = await JellyfinRepository.listRecentEpisodesBySeries(
+        ctx.uuid,
+        limit * 2
+      );
+      const candidates = recent.filter(
+        (row): row is typeof row & { payload: { t: string; i: string } } =>
+          row.payload.k === 'episode'
+      );
+      const nexts = await lookup(
+        candidates,
+        async (row) => {
+          const next = await nextUpForSeries(
+            ctx,
+            { t: row.payload.t, i: row.payload.i },
+            row
+          );
+          return next && !(next.UserData as { Played: boolean }).Played
+            ? [next]
+            : [];
+        },
+        { target: limit, what: 'series in Next Up' }
+      );
+      items.push(...nexts.slice(0, limit));
+    }
+    res.json(list(items, items.length, 0));
+  })
+);
+
+router.get(
+  '/Shows/Upcoming',
+  jf(async (_req, res) => {
+    res.json(list([], 0, 0));
+  })
+);
+
+router.get(
+  '/Shows/:seriesId/Seasons',
+  jf(async (req, res, ctx) => {
+    const d = await decodeJellyfinId(param(req, 'seriesId'));
+    if (!d || (d.k !== 'series' && d.k !== 'movie')) {
+      res.status(404).json({ Message: 'Series not found' });
+      return;
+    }
+    const r = await seasonsForSeries(ctx, d);
+    const seasons = r?.seasons ?? [];
+    res.json(list(seasons, seasons.length, 0));
+  })
+);
+
+router.get(
+  '/Shows/:seriesId/Episodes',
+  jf(async (req, res, ctx) => {
+    const d = await decodeJellyfinId(param(req, 'seriesId'));
+    if (!d || (d.k !== 'series' && d.k !== 'movie')) {
+      res.status(404).json({ Message: 'Series not found' });
+      return;
+    }
+    let season: number | undefined;
+    const seasonId = qs(req, 'SeasonId');
+    if (seasonId) {
+      const sd = await decodeJellyfinId(seasonId);
+      if (sd?.k === 'season') season = sd.s;
+    }
+    const seasonNum = qs(req, 'Season');
+    if (season == null && seasonNum != null && seasonNum !== '')
+      season = Number(seasonNum);
+    const r = await episodesForSeries(ctx, d, season);
+    let eps = r?.episodes ?? [];
+    const startItemId = qs(req, 'StartItemId');
+    if (startItemId) {
+      const idx = eps.findIndex((e) => e.Id === startItemId);
+      if (idx >= 0) eps = eps.slice(idx);
+    }
+    const adjacentTo = qs(req, 'AdjacentTo');
+    if (adjacentTo) {
+      const idx = eps.findIndex((e) => e.Id === adjacentTo);
+      if (idx >= 0) eps = eps.slice(Math.max(0, idx - 1), idx + 2);
+    }
+    const startIndex = Math.max(0, qi(req, 'StartIndex', 0));
+    const limit = Math.min(Math.max(1, qi(req, 'Limit', 1000)), 2000);
+    res.json(
+      list(eps.slice(startIndex, startIndex + limit), eps.length, startIndex)
+    );
+  })
+);
+
+async function sendItem(
+  req: Request,
+  res: import('express').Response,
+  ctx: JellyfinRequestContext,
+  id: string
+) {
+  const r = await itemFromId(ctx, id);
+  if (!r) {
+    res.status(404).json({ Message: 'Item not found' });
+    return;
+  }
+  const { item, descriptor } = r;
+  const wantsSources = qlist(req, 'Fields').some(
+    (f) => f.toLowerCase() === 'mediasources'
+  );
+  const target = !wantsSources
+    ? null
+    : descriptor.k === 'movie'
+      ? {
+          type: descriptor.t,
+          videoId: await ctx.service.resolveVideoId(descriptor.t, descriptor.i),
+        }
+      : descriptor.k === 'episode'
+        ? { type: descriptor.t, videoId: descriptor.v }
+        : null;
+  if (target) {
+    try {
+      const { sources } = await ctx.service.buildMediaSources(
+        target.type,
+        target.videoId,
+        {
+          baseUrl: ctx.baseUrl,
+          itemId: item.Id,
+          apiKey: ctx.apiKey,
+          encrypt: encryptToken,
+          runtimeTicks: item.RunTimeTicks as number | undefined,
+        }
+      );
+      const capped = sources.slice(0, MAX_MEDIA_SOURCES);
+      if (capped.length) {
+        capped[0] = { ...capped[0], Id: item.Id, ETag: item.Id };
+        item.MediaSources = capped;
+        item.MediaStreams = capped[0].MediaStreams;
+        item.Container = capped[0].Container;
+      } else {
+        item.MediaSources = [
+          {
+            Id: item.Id,
+            ETag: item.Id,
+            Name: 'No streams found',
+            Path: `/aiostreams/${item.Id}`,
+            Protocol: 'File',
+            Type: 'Default',
+            SupportsDirectPlay: true,
+            SupportsDirectStream: true,
+            SupportsTranscoding: false,
+            MediaStreams: [],
+            Formats: [],
+          },
+        ];
+      }
+    } catch (e) {}
+  }
+  res.json(stripInternal(item));
+}
+
+const RESERVED_ITEM_IDS =
+  /^(Filters2?|Counts|Latest|Resume|Intros|Root|Suggestions)$/i;
+router.get(
+  ['/Users/:userId/Items/:itemId', '/Items/:itemId'],
+  (req, _res, next) =>
+    RESERVED_ITEM_IDS.test(param(req, 'itemId')) ? next('route') : next(),
+  jf(async (req, res, ctx) => {
+    await sendItem(req, res, ctx, param(req, 'itemId'));
+  })
+);
+
+router.get(
+  '/Items/:itemId/Ancestors',
+  jf(async (req, res, ctx) => {
+    const d = await decodeJellyfinId(param(req, 'itemId'));
+    const out: JellyfinItem[] = [];
+    if (d?.k === 'episode') {
+      const season = await itemFromDescriptor(ctx, {
+        k: 'season',
+        t: d.t,
+        i: d.i,
+        s: d.s,
+      });
+      const series = await itemFromDescriptor(ctx, {
+        k: 'series',
+        t: d.t,
+        i: d.i,
+      });
+      if (season) out.push(season);
+      if (series) out.push(series);
+    } else if (d?.k === 'season') {
+      const series = await itemFromDescriptor(ctx, {
+        k: 'series',
+        t: d.t,
+        i: d.i,
+      });
+      if (series) out.push(series);
+    }
+    res.json(out.map(stripInternal));
+  })
+);
+
+router.get(
+  [
+    '/Items/:itemId/Similar',
+    '/Movies/:itemId/Similar',
+    '/Shows/:itemId/Similar',
+  ],
+  jf(async (req, res, ctx) => {
+    const d = await decodeJellyfinId(param(req, 'itemId'));
+    const limit = Math.min(Math.max(1, qi(req, 'Limit', 12)), 50);
+    if (!d || (d.k !== 'movie' && d.k !== 'series')) {
+      res.json(list([], 0, 0));
+      return;
+    }
+    const meta = await ctx.service.getMetaLoose(d.t, d.i);
+    const genre = (meta?.genres ?? [])[0];
+    if (!genre) {
+      res.json(list([], 0, 0));
+      return;
+    }
+    const catalogs = await ctx.service.getCatalogs();
+    for (const catalog of catalogs) {
+      if (catalog.type !== d.t) continue;
+      const opts =
+        (catalog.extra ?? []).find((e) => e.name === 'genre')?.options ?? [];
+      if (!opts.includes(genre)) continue;
+      const page = await ctx.service.getCatalogPage(catalog, {
+        startIndex: 0,
+        limit: limit + 1,
+        genre,
+      });
+      const items = (
+        await itemsFromPreviews(
+          ctx,
+          page.items.filter((p) => p.id !== d.i)
+        )
+      ).slice(0, limit);
+      res.json(list(items, items.length, 0));
+      return;
+    }
+    res.json(list([], 0, 0));
+  })
+);
+
+router.get(
+  '/Movies/Recommendations',
+  jf(async (req, res, ctx) => {
+    const limit = Math.min(Math.max(1, qi(req, 'ItemLimit', 8)), 20);
+    const catalogs = (await ctx.service.getCatalogs())
+      .filter((c) => c.type === 'movie')
+      .slice(0, 3);
+    const out: {
+      Items: JellyfinItem[];
+      RecommendationType: string;
+      BaselineItemName: string;
+      CategoryId: string;
+    }[] = [];
+    for (const catalog of catalogs) {
+      const page = await ctx.service.getCatalogPage(catalog, {
+        startIndex: 0,
+        limit,
+      });
+      const items = await itemsFromPreviews(ctx, page.items);
+      out.push({
+        Items: items.map(stripInternal),
+        RecommendationType: 'SimilarToRecentlyPlayed',
+        BaselineItemName: catalog.name,
+        CategoryId: encodeJellyfinId({
+          k: 'view',
+          t: catalog.type,
+          c: catalog.id,
+        }),
+      });
+    }
+    res.json(out);
+  })
+);
+
+for (const p of [
+  '/Items/:itemId/ThemeMedia',
+  '/Items/:itemId/ThemeSongs',
+  '/Items/:itemId/ThemeVideos',
+]) {
+  router.get(
+    p,
+    jf(async (req, res) => {
+      const empty = {
+        Items: [],
+        TotalRecordCount: 0,
+        StartIndex: 0,
+        OwnerId: param(req, 'itemId'),
+      };
+      if (/ThemeMedia/.test(p))
+        res.json({
+          ThemeVideosResult: empty,
+          ThemeSongsResult: empty,
+          SoundtrackSongsResult: empty,
+        });
+      else res.json(empty);
+    })
+  );
+}
+router.get(
+  [
+    '/Items/:itemId/SpecialFeatures',
+    '/Users/:userId/Items/:itemId/SpecialFeatures',
+    '/Users/:userId/Items/:itemId/LocalTrailers',
+    '/Items/:itemId/LocalTrailers',
+    '/Users/:userId/Items/:itemId/Intros',
+    '/Items/:itemId/Intros',
+  ],
+  jf(async (req, res) => {
+    if (/Intros/.test(req.path))
+      res.json({ Items: [], TotalRecordCount: 0, StartIndex: 0 });
+    else res.json([]);
+  })
+);
+router.get(
+  '/MediaSegments/:itemId',
+  jf(async (_req, res) => {
+    res.json({ Items: [], TotalRecordCount: 0, StartIndex: 0 });
+  })
+);
+
+router.get(
+  '/Genres',
+  jf(async (req, res, ctx) => {
+    const parentId = qs(req, 'ParentId');
+    const catalogs = await ctx.service.getCatalogs();
+    const genresOut: JellyfinItem[] = [];
+    const seen = new Set<string>();
+    let scoped = catalogs;
+    if (parentId) {
+      const d = await decodeJellyfinId(parentId);
+      if (d?.k === 'view')
+        scoped = catalogs.filter((c) => c.type === d.t && c.id === d.c);
+    }
+    for (const catalog of scoped) {
+      for (const g of await ctx.service.getCatalogGenres(catalog)) {
+        const key = `${catalog.type}|${g}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        genresOut.push(buildGenreItem(ctx.build, catalog.type, catalog.id, g));
+      }
+    }
+    res.json(list(genresOut, genresOut.length, 0));
+  })
+);
+router.get(
+  '/Genres/:name',
+  jf(async (req, res, ctx) => {
+    res.json(
+      stripInternal(
+        buildGenreItem(
+          ctx.build,
+          'movie',
+          '',
+          decodeURIComponent(param(req, 'name'))
+        )
+      )
+    );
+  })
+);
+
+router.get(
+  ['/Items/Filters', '/Items/Filters2'],
+  jf(async (req, res, ctx) => {
+    const parentId = qs(req, 'ParentId');
+    const catalogs = await ctx.service.getCatalogs();
+    let scoped = catalogs;
+    if (parentId) {
+      const d = await decodeJellyfinId(parentId);
+      if (d?.k === 'view')
+        scoped = catalogs.filter((c) => c.type === d.t && c.id === d.c);
+    }
+    const genres: { Name: string; Id: string }[] = [];
+    const seen = new Set<string>();
+    for (const catalog of scoped) {
+      for (const g of await ctx.service.getCatalogGenres(catalog)) {
+        if (seen.has(g)) continue;
+        seen.add(g);
+        genres.push({
+          Name: g,
+          Id: encodeJellyfinId({
+            k: 'genre',
+            t: catalog.type,
+            c: catalog.id,
+            g,
+          }),
+        });
+      }
+    }
+    if (/Filters2/i.test(req.path)) {
+      res.json({ Genres: genres, Tags: [] });
+    } else {
+      res.json({
+        Genres: genres.map((g) => g.Name),
+        Tags: [],
+        OfficialRatings: [],
+        Years: [],
+      });
+    }
+  })
+);
+
+router.get(
+  '/Items/Counts',
+  jf(async (_req, res) => {
+    res.json({
+      MovieCount: 0,
+      SeriesCount: 0,
+      EpisodeCount: 0,
+      ArtistCount: 0,
+      ProgramCount: 0,
+      TrailerCount: 0,
+      SongCount: 0,
+      AlbumCount: 0,
+      MusicVideoCount: 0,
+      BoxSetCount: 0,
+      BookCount: 0,
+      ItemCount: 0,
+    });
+  })
+);
+
+router.get(
+  '/Search/Hints',
+  jf(async (req, res, ctx) => {
+    const term = (qs(req, 'SearchTerm') ?? qs(req, 'searchTerm') ?? '').trim();
+    const limit = Math.min(Math.max(1, qi(req, 'Limit', 20)), 50);
+    const types = includeTypes(req);
+    if (!term) {
+      res.json({ SearchHints: [], TotalRecordCount: 0 });
+      return;
+    }
+    const previews = await ctx.service.search(
+      term,
+      stremioTypesFor(types),
+      limit
+    );
+    const items = filterByType(await itemsFromPreviews(ctx, previews), types);
+    res.json({
+      SearchHints: items.map((i) => ({
+        ItemId: i.Id,
+        Id: i.Id,
+        Name: i.Name,
+        Type: i.Type,
+        MediaType: i.MediaType ?? 'Video',
+        ProductionYear: i.ProductionYear,
+        PrimaryImageTag: (i.ImageTags as Record<string, string>)?.Primary,
+        BackdropImageTag: (i.BackdropImageTags as string[])?.[0],
+        BackdropImageItemId: i.Id,
+        PrimaryImageAspectRatio: i.PrimaryImageAspectRatio,
+        RunTimeTicks: i.RunTimeTicks,
+        IsFolder: i.IsFolder,
+      })),
+      TotalRecordCount: items.length,
+    });
+  })
+);
+
+router.get(
+  '/Persons/:name',
+  jf(async (req, res, ctx) => {
+    const item = await itemFromDescriptor(ctx, {
+      k: 'person',
+      n: decodeURIComponent(param(req, 'name')),
+    });
+    res.json(item ? stripInternal(item) : { Message: 'Not found' });
+  })
+);
+
+async function toggleFavorite(
+  ctx: JellyfinRequestContext,
+  itemId: string,
+  favorite: boolean
+) {
+  const d = await decodeJellyfinId(itemId);
+  if (!d) return null;
+  const row = await JellyfinRepository.upsertPlaystate(
+    ctx.uuid,
+    itemId.replace(/-/g, '').toLowerCase(),
+    d,
+    { favorite }
+  );
+  return row;
+}
+
+router.post(
+  ['/Users/:userId/FavoriteItems/:itemId', '/UserFavoriteItems/:itemId'],
+  jf(async (req, res, ctx) => {
+    const row = await toggleFavorite(ctx, param(req, 'itemId'), true);
+    if (!row) {
+      res.status(404).json({ Message: 'Item not found' });
+      return;
+    }
+    const item = await itemFromDescriptor(ctx, row.payload, { playstate: row });
+    res.json(item?.UserData ?? { IsFavorite: true });
+  })
+);
+router.delete(
+  ['/Users/:userId/FavoriteItems/:itemId', '/UserFavoriteItems/:itemId'],
+  jf(async (req, res, ctx) => {
+    const row = await toggleFavorite(ctx, param(req, 'itemId'), false);
+    if (!row) {
+      res.status(404).json({ Message: 'Item not found' });
+      return;
+    }
+    const item = await itemFromDescriptor(ctx, row.payload, { playstate: row });
+    res.json(item?.UserData ?? { IsFavorite: false });
+  })
+);
+
+export default router;

--- a/packages/server/src/routes/jellyfin/library.ts
+++ b/packages/server/src/routes/jellyfin/library.ts
@@ -52,7 +52,7 @@ function lookup<T, R>(
   return collectConcurrent(items, fn, {
     concurrency: appConfig.api.jellyfinLookupConcurrency,
     target: opts.target,
-    onError: (error) =>
+    onError: (error: unknown) =>
       logger.debug(
         { err: error instanceof Error ? error.message : String(error) },
         `skipping unresolvable ${opts.what}`

--- a/packages/server/src/routes/jellyfin/playback.ts
+++ b/packages/server/src/routes/jellyfin/playback.ts
@@ -1,0 +1,825 @@
+import { Router, type Request, type Response } from 'express';
+import { pipeline } from 'stream/promises';
+import { Readable } from 'stream';
+import {
+  config as appConfig,
+  createLogger,
+  decodeJellyfinId,
+  decryptString,
+  encryptString,
+  JellyfinRepository,
+  makeRequest,
+  recallImages,
+  rememberImages,
+  parseRuntimeToTicks,
+  type ItemImages,
+  type JellyfinItemDescriptor,
+  type PlayableStreamRecord,
+  type RememberedImages,
+} from '@aiostreams/core';
+import { jf, qs, type JellyfinRequestContext, param } from './context.js';
+import { isRelayLoop } from './relay-target.js';
+
+const logger = createLogger('jellyfin');
+const router: Router = Router({ mergeParams: true });
+
+const RELAY_OPTIONS = { ignoreRecursion: true } as const;
+
+let selfOriginsMemo: Set<string> | null = null;
+function selfOrigins(): Set<string> {
+  if (selfOriginsMemo) return selfOriginsMemo;
+  const origins = new Set<string>();
+  for (const candidate of [
+    appConfig.bootstrap.baseUrl,
+    appConfig.bootstrap.internalUrl,
+    `http://localhost:${appConfig.bootstrap.port}`,
+  ]) {
+    if (!candidate) continue;
+    try {
+      origins.add(new URL(candidate).origin);
+    } catch {}
+  }
+  selfOriginsMemo = origins;
+  return origins;
+}
+
+async function relay(url: string, headers?: Record<string, string>) {
+  if (isRelayLoop(url, selfOrigins())) {
+    throw new Error('relay target loops back to this server');
+  }
+  const timeout = appConfig.api.jellyfinRelayTimeout;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  try {
+    return await makeRequest(url, {
+      ...RELAY_OPTIONS,
+      timeout,
+      signal: controller.signal,
+      headers,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function encrypt(plain: string): string {
+  const r = encryptString(plain);
+  if (!r.success || !r.data) throw new Error('encryption failed');
+  return r.data;
+}
+
+function decrypt(token: string): string | null {
+  const r = decryptString(token);
+  return r.success && r.data != null ? r.data : null;
+}
+
+async function playTarget(
+  ctx: JellyfinRequestContext,
+  d: JellyfinItemDescriptor
+): Promise<{ type: string; videoId: string; seriesId?: string } | null> {
+  if (d.k === 'movie')
+    return { type: d.t, videoId: await ctx.service.resolveVideoId(d.t, d.i) };
+  if (d.k === 'episode') return { type: d.t, videoId: d.v, seriesId: d.i };
+  if (d.k === 'series')
+    return {
+      type: d.t,
+      videoId: await ctx.service.resolveVideoId(d.t, d.i),
+      seriesId: d.i,
+    };
+  return null;
+}
+
+async function runtimeTicksFor(
+  ctx: JellyfinRequestContext,
+  d: JellyfinItemDescriptor
+): Promise<number | undefined> {
+  if (d.k !== 'movie' && d.k !== 'episode' && d.k !== 'series')
+    return undefined;
+  const meta = await ctx.service.getMetaLoose(d.t, d.i).catch(() => null);
+  return parseRuntimeToTicks(meta?.runtime);
+}
+
+async function playbackInfo(
+  req: Request,
+  res: Response,
+  ctx: JellyfinRequestContext
+) {
+  const itemId = param(req, 'itemId');
+  const d = await decodeJellyfinId(itemId);
+  const target = d ? await playTarget(ctx, d) : null;
+  if (!d || !target) {
+    res
+      .status(404)
+      .json({ MediaSources: [], PlaySessionId: '', ErrorCode: 'NotAllowed' });
+    return;
+  }
+  const requestedSource =
+    qs(req, 'MediaSourceId') ??
+    (req.body as Record<string, unknown> | undefined)?.MediaSourceId;
+  const runtimeTicks = await runtimeTicksFor(ctx, d);
+  const { sources, errors } = await ctx.service.buildMediaSources(
+    target.type,
+    target.videoId,
+    {
+      baseUrl: ctx.baseUrl,
+      itemId: itemId.replace(/-/g, '').toLowerCase(),
+      apiKey: ctx.apiKey,
+      encrypt,
+      runtimeTicks,
+    }
+  );
+  const normalizedItemId = itemId.replace(/-/g, '').toLowerCase();
+  let out = sources.slice(0, 50);
+  const specific =
+    typeof requestedSource === 'string' &&
+    requestedSource &&
+    requestedSource.replace(/-/g, '').toLowerCase() !== normalizedItemId;
+  if (specific) {
+    const picked = sources.filter((s) => s.Id === requestedSource);
+    if (picked.length) out = picked;
+  }
+  if (!specific && out.length) {
+    out[0] = { ...out[0], Id: normalizedItemId, ETag: normalizedItemId };
+  }
+  if (!out.length) {
+    const reason = errors
+      .map((e) => [e.title, e.description].filter(Boolean).join(': '))
+      .join('; ');
+    logger.warn(
+      { itemId, type: target.type, videoId: target.videoId, reason },
+      'no playable sources'
+    );
+    res.json({
+      MediaSources: [],
+      PlaySessionId: `${ctx.userId}-${Date.now()}`,
+      ErrorCode: 'NoCompatibleStream',
+    });
+    return;
+  }
+  res.json({
+    MediaSources: out,
+    PlaySessionId: `${ctx.userId}-${Date.now().toString(36)}`,
+  });
+}
+
+router.get('/Items/:itemId/PlaybackInfo', jf(playbackInfo));
+router.post('/Items/:itemId/PlaybackInfo', jf(playbackInfo));
+
+router.get(
+  '/Items/:itemId/MediaSources',
+  jf(async (req, res, ctx) => {
+    await playbackInfo(req, res, ctx);
+  })
+);
+
+interface StreamTarget {
+  url: string;
+  headers?: Record<string, string>;
+  responseHeaders?: Record<string, string>;
+  filename?: string;
+}
+
+async function resolveStreamTarget(
+  req: Request,
+  ctx: JellyfinRequestContext,
+  d: JellyfinItemDescriptor
+): Promise<StreamTarget | null> {
+  const t = qs(req, 't');
+  if (t) {
+    const plain = decrypt(t);
+    if (plain) {
+      try {
+        const parsed = JSON.parse(plain) as {
+          u: string;
+          h?: Record<string, string>;
+          r?: Record<string, string>;
+          f?: string;
+        };
+        if (parsed.u)
+          return {
+            url: parsed.u,
+            headers: parsed.h,
+            responseHeaders: parsed.r,
+            filename: parsed.f,
+          };
+      } catch {}
+    }
+  }
+  const target = await playTarget(ctx, d);
+  if (!target) return null;
+  const rawMsid = qs(req, 'MediaSourceId');
+  const itemGuid = param(req, 'itemId').replace(/-/g, '').toLowerCase();
+  const msid =
+    rawMsid && rawMsid.replace(/-/g, '').toLowerCase() === itemGuid
+      ? undefined
+      : rawMsid;
+  const playable = await ctx.service.resolvePlayable(
+    target.type,
+    target.videoId
+  );
+  if (!playable.length) return null;
+  const pick: PlayableStreamRecord | undefined = msid
+    ? playable.find((p) => p.msid === msid)
+    : playable[0];
+  const chosen = pick ?? playable[0];
+  return {
+    url: chosen.url,
+    headers: chosen.headers,
+    responseHeaders: chosen.responseHeaders,
+    filename: chosen.filename,
+  };
+}
+
+async function streamHandler(
+  req: Request,
+  res: Response,
+  ctx: JellyfinRequestContext
+) {
+  const d = await decodeJellyfinId(param(req, 'itemId'));
+  if (!d) {
+    res.status(404).json({ Message: 'Item not found' });
+    return;
+  }
+  const target = await resolveStreamTarget(req, ctx, d);
+  if (!target) {
+    res.status(404).json({ Message: 'No playable stream' });
+    return;
+  }
+  res.redirect(302, target.url);
+}
+
+router.get(
+  [
+    '/Videos/:itemId/stream',
+    '/Videos/:itemId/stream.:ext',
+    '/Videos/:itemId/stream/:filename',
+    '/Videos/:itemId/original',
+    '/Videos/:itemId/original.:ext',
+    '/Items/:itemId/Download',
+    '/Items/:itemId/File',
+  ],
+  jf(streamHandler)
+);
+router.head(
+  [
+    '/Videos/:itemId/stream',
+    '/Videos/:itemId/stream.:ext',
+    '/Videos/:itemId/stream/:filename',
+    '/Items/:itemId/Download',
+  ],
+  jf(streamHandler)
+);
+
+router.get(
+  [
+    '/Videos/:itemId/master.m3u8',
+    '/Videos/:itemId/main.m3u8',
+    '/Videos/:itemId/live.m3u8',
+    '/Videos/:itemId/hls1/{*rest}',
+    '/Videos/:itemId/hls/{*rest}',
+  ],
+  jf(async (_req, res) => {
+    res.status(501).json({
+      Message: 'Transcoding is not supported by this server; use direct play.',
+    });
+  })
+);
+router.delete('/Videos/ActiveEncodings', (_req, res) => {
+  res.status(204).end();
+});
+
+router.get(
+  [
+    '/Videos/:itemId/:mediaSourceId/Subtitles/:index/Stream.:format',
+    '/Videos/:itemId/:mediaSourceId/Subtitles/:index/:start/Stream.:format',
+  ],
+  jf(async (req, res, ctx) => {
+    const u = qs(req, 'u');
+    let url = u ? decrypt(u) : null;
+    if (!url) {
+      const d = await decodeJellyfinId(param(req, 'itemId'));
+      const target = d ? await playTarget(ctx, d) : null;
+      if (target) {
+        const playable = await ctx.service.resolvePlayable(
+          target.type,
+          target.videoId
+        );
+        const rec = playable.find(
+          (p) => p.msid === param(req, 'mediaSourceId')
+        );
+        const idx = Number(param(req, 'index'));
+        const subs = [
+          ...(rec?.subtitles ?? []),
+          ...(await ctx.service.getSubtitles(target.type, target.videoId)),
+        ];
+        url = subs[idx]?.url ?? null;
+      }
+    }
+    if (!url) {
+      res.status(404).end();
+      return;
+    }
+    try {
+      const upstream = await relay(url);
+      if (!upstream.ok || !upstream.body) {
+        res.status(upstream.status >= 400 ? upstream.status : 502).end();
+        return;
+      }
+      res.status(200);
+      res.setHeader(
+        'content-type',
+        upstream.headers.get('content-type') ?? 'text/plain; charset=utf-8'
+      );
+      await pipeline(
+        Readable.fromWeb(upstream.body as import('stream/web').ReadableStream),
+        res
+      ).catch(() => undefined);
+    } catch (error) {
+      logger.debug(
+        { err: error instanceof Error ? error.message : String(error) },
+        'subtitle relay failed'
+      );
+      if (!res.headersSent) res.status(502).end();
+    }
+  })
+);
+
+const FALLBACK_IMAGE = '/logo.png';
+
+function metahubImageUrl(
+  d: JellyfinItemDescriptor,
+  want: string
+): string | null {
+  if (!('i' in d) || typeof d.i !== 'string' || !d.i.startsWith('tt'))
+    return null;
+  if (d.k === 'episode')
+    return `https://images.metahub.space/background/medium/${d.i}/img`;
+  if (d.k !== 'movie' && d.k !== 'series' && d.k !== 'season') return null;
+  if (want === 'primary' || want === 'thumb')
+    return `https://images.metahub.space/poster/medium/${d.i}/img`;
+  if (want === 'backdrop' || want === 'art' || want === 'banner')
+    return `https://images.metahub.space/background/medium/${d.i}/img`;
+  if (want === 'logo')
+    return `https://images.metahub.space/logo/medium/${d.i}/img`;
+  return null;
+}
+
+interface ResolvedImage {
+  url: string;
+  public: boolean;
+}
+
+const ARTWORK_KINDS = new Set(['movie', 'series', 'season', 'episode']);
+
+const inflightRebuilds = new Map<
+  string,
+  Promise<RememberedImages | undefined>
+>();
+
+async function rebuildImages(
+  uuid: string | undefined,
+  getCtx: () => Promise<JellyfinRequestContext | null>,
+  d: JellyfinItemDescriptor,
+  id: string
+): Promise<RememberedImages | undefined> {
+  const run = async (): Promise<RememberedImages | undefined> => {
+    const ctx = await getCtx().catch(() => null);
+    if (!ctx) return undefined;
+    const { itemFromDescriptor } = await import('./items.js');
+    const ran = await itemFromDescriptor(ctx, d).then(
+      () => true,
+      () => false
+    );
+    const found = await recallImages(ctx.uuid, id);
+    if (found?.complete) return found;
+    if (!ran) return found;
+    const settled = { images: found?.images ?? {}, complete: true };
+    rememberImages(ctx.uuid, id, settled.images, true);
+    return settled;
+  };
+  if (!uuid) return run();
+  const cacheKey = `${uuid}|${id}`;
+  let inFlight = inflightRebuilds.get(cacheKey);
+  if (!inFlight) {
+    inFlight = run().finally(() => inflightRebuilds.delete(cacheKey));
+    inflightRebuilds.set(cacheKey, inFlight);
+  }
+  return inFlight;
+}
+
+async function imageUrlFor(
+  uuid: string | undefined,
+  getCtx: () => Promise<JellyfinRequestContext | null>,
+  itemId: string,
+  type: string,
+  opts: { rebuild?: boolean } = {}
+): Promise<ResolvedImage | null> {
+  const id = itemId.replace(/-/g, '').toLowerCase();
+  const want = type.toLowerCase();
+  const pick = (imgs: ItemImages | undefined) => {
+    if (!imgs) return null;
+    switch (want) {
+      case 'primary':
+        return imgs.Primary ?? imgs.Thumb ?? imgs.Backdrop ?? null;
+      case 'backdrop':
+      case 'art':
+      case 'banner':
+        return imgs.Backdrop ?? imgs.Primary ?? null;
+      case 'thumb':
+        return imgs.Thumb ?? imgs.Backdrop ?? imgs.Primary ?? null;
+      case 'logo':
+        return imgs.Logo ?? null;
+      default:
+        return imgs.Primary ?? null;
+    }
+  };
+  const remembered = uuid ? await recallImages(uuid, id) : undefined;
+  const cached = pick(remembered?.images);
+  if (cached) return { url: cached, public: false };
+  const d = await decodeJellyfinId(id);
+  if (!d) return null;
+  if (!ARTWORK_KINDS.has(d.k)) return null;
+  if (opts.rebuild !== false && !remembered?.complete) {
+    const rebuilt = pick((await rebuildImages(uuid, getCtx, d, id))?.images);
+    if (rebuilt) return { url: rebuilt, public: false };
+  }
+  const fallback = metahubImageUrl(d, want);
+  return fallback ? { url: fallback, public: true } : null;
+}
+
+function lazyCtx(req: Request): () => Promise<JellyfinRequestContext | null> {
+  return () =>
+    req.jf
+      ? Promise.resolve(req.jf)
+      : (req.jfLazy?.() ?? Promise.resolve(null));
+}
+
+router.get(
+  ['/Items/:itemId/Images/:type', '/Items/:itemId/Images/:type/:index'],
+  async (req, res) => {
+    const result = await imageUrlFor(
+      req.uuid,
+      lazyCtx(req),
+      param(req, 'itemId'),
+      param(req, 'type')
+    ).catch(() => null);
+    if (!result) {
+      res.status(404).end();
+      return;
+    }
+    try {
+      const headers: Record<string, string> = {};
+      const inm = req.headers['if-none-match'];
+      if (typeof inm === 'string') headers['if-none-match'] = inm;
+      const ims = req.headers['if-modified-since'];
+      if (typeof ims === 'string') headers['if-modified-since'] = ims;
+      const upstream = await relay(result.url, headers);
+      res.status(upstream.status);
+      for (const h of [
+        'content-type',
+        'content-length',
+        'etag',
+        'last-modified',
+        'cache-control',
+        'expires',
+      ]) {
+        const v = upstream.headers.get(h);
+        if (v) res.setHeader(h, v);
+      }
+      if (!upstream.body || upstream.status === 304) {
+        res.end();
+        return;
+      }
+      await pipeline(
+        Readable.fromWeb(upstream.body as import('stream/web').ReadableStream),
+        res
+      ).catch(() => undefined);
+    } catch (error) {
+      logger.debug(
+        { err: error instanceof Error ? error.message : String(error) },
+        'image relay failed'
+      );
+      if (res.headersSent) return;
+      if (result.public) res.redirect(302, result.url);
+      else res.status(502).end();
+    }
+  }
+);
+router.head(
+  ['/Items/:itemId/Images/:type', '/Items/:itemId/Images/:type/:index'],
+  async (req, res) => {
+    const result = await imageUrlFor(
+      req.uuid,
+      lazyCtx(req),
+      param(req, 'itemId'),
+      param(req, 'type'),
+      { rebuild: false }
+    ).catch(() => null);
+    if (!result) {
+      res.status(404).end();
+      return;
+    }
+    res.status(200).end();
+  }
+);
+router.get(
+  '/Items/:itemId/Images',
+  jf(async (req, res, ctx) => {
+    const id = param(req, 'itemId').replace(/-/g, '').toLowerCase();
+    const imgs = (await recallImages(ctx.uuid, id))?.images ?? {};
+    const out = Object.entries(imgs)
+      .filter(([, v]) => !!v)
+      .map(([k]) => ({
+        ImageType: k,
+        ImageIndex: k === 'Backdrop' ? 0 : undefined,
+        Path: '',
+        Size: 0,
+        Width: 0,
+        Height: 0,
+      }));
+    res.json(out);
+  })
+);
+router.get(
+  [
+    '/Users/:userId/Images/:type',
+    '/Users/:userId/Images/:type/:index',
+    '/UserImage',
+  ],
+  (_req, res) => {
+    res.redirect(302, FALLBACK_IMAGE);
+  }
+);
+router.get(['/Branding/Splashscreen'], (_req, res) => {
+  res.redirect(302, FALLBACK_IMAGE);
+});
+router.get('/Images/General/:name/:type', (_req, res) => {
+  res.redirect(302, FALLBACK_IMAGE);
+});
+
+function ticksFrom(
+  body: Record<string, unknown>,
+  req: Request,
+  key: string
+): number | undefined {
+  const v =
+    body[key] ??
+    body[key.charAt(0).toLowerCase() + key.slice(1)] ??
+    qs(req, key);
+  if (v == null || v === '') return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function idFrom(
+  body: Record<string, unknown>,
+  req: Request
+): string | undefined {
+  const v =
+    body.ItemId ?? body.itemId ?? qs(req, 'ItemId') ?? param(req, 'itemId');
+  return typeof v === 'string' && v
+    ? v.replace(/-/g, '').toLowerCase()
+    : undefined;
+}
+
+const PLAYED_THRESHOLD = 0.9;
+
+const PROGRESS_MIN_DELTA_TICKS = 30 * 10_000_000;
+const PROGRESS_MIN_WALL_MS = 60_000;
+const lastProgressWrite = new Map<string, { pos: number; at: number }>();
+const LAST_PROGRESS_MAX = 20_000;
+
+async function recordProgress(
+  ctx: JellyfinRequestContext,
+  itemId: string,
+  positionTicks: number | undefined,
+  event: 'start' | 'progress' | 'stop'
+) {
+  const d = await decodeJellyfinId(itemId);
+  if (!d || (d.k !== 'movie' && d.k !== 'episode')) return;
+  const throttleKey = `${ctx.uuid}:${itemId}`;
+  if (event === 'progress' && positionTicks != null) {
+    const last = lastProgressWrite.get(throttleKey);
+    if (
+      last &&
+      Math.abs(positionTicks - last.pos) < PROGRESS_MIN_DELTA_TICKS &&
+      Date.now() - last.at < PROGRESS_MIN_WALL_MS
+    ) {
+      return;
+    }
+  }
+  if (lastProgressWrite.size >= LAST_PROGRESS_MAX) lastProgressWrite.clear();
+  lastProgressWrite.set(throttleKey, {
+    pos: positionTicks ?? 0,
+    at: Date.now(),
+  });
+  const runtimeTicks = (await runtimeTicksFor(ctx, d)) ?? 0;
+  const existing = await JellyfinRepository.getPlaystate(ctx.uuid, itemId);
+  const rt = runtimeTicks || existing?.runtimeTicks || 0;
+  const pos = positionTicks ?? existing?.positionTicks ?? 0;
+  const now = Date.now();
+  if (event === 'start') {
+    await JellyfinRepository.upsertPlaystate(ctx.uuid, itemId, d, {
+      runtimeTicks: rt || undefined,
+      positionTicks: positionTicks ?? undefined,
+      lastPlayedAt: now,
+    });
+    return;
+  }
+  const finished = rt > 0 && pos >= rt * PLAYED_THRESHOLD;
+  if (finished) {
+    await JellyfinRepository.upsertPlaystate(ctx.uuid, itemId, d, {
+      positionTicks: 0,
+      runtimeTicks: rt || undefined,
+      played: true,
+      incrementPlayCount: event === 'stop' ? 'if-unplayed' : false,
+      lastPlayedAt: now,
+    });
+    return;
+  }
+  await JellyfinRepository.upsertPlaystate(ctx.uuid, itemId, d, {
+    positionTicks: pos,
+    runtimeTicks: rt || undefined,
+    played: false,
+    lastPlayedAt: now,
+  });
+}
+
+router.post(
+  ['/Sessions/Playing', '/PlayingItems/:itemId'],
+  jf(async (req, res, ctx) => {
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const id = idFrom(body, req);
+    if (id)
+      await recordProgress(
+        ctx,
+        id,
+        ticksFrom(body, req, 'PositionTicks'),
+        'start'
+      );
+    res.status(204).end();
+  })
+);
+router.post(
+  ['/Sessions/Playing/Progress', '/PlayingItems/:itemId/Progress'],
+  jf(async (req, res, ctx) => {
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const id = idFrom(body, req);
+    if (id)
+      await recordProgress(
+        ctx,
+        id,
+        ticksFrom(body, req, 'PositionTicks'),
+        'progress'
+      );
+    res.status(204).end();
+  })
+);
+router.post(
+  ['/Sessions/Playing/Stopped'],
+  jf(async (req, res, ctx) => {
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const id = idFrom(body, req);
+    if (id)
+      await recordProgress(
+        ctx,
+        id,
+        ticksFrom(body, req, 'PositionTicks'),
+        'stop'
+      );
+    res.status(204).end();
+  })
+);
+router.delete(
+  '/PlayingItems/:itemId',
+  jf(async (req, res, ctx) => {
+    const id = idFrom({}, req);
+    if (id)
+      await recordProgress(
+        ctx,
+        id,
+        ticksFrom({}, req, 'PositionTicks'),
+        'stop'
+      );
+    res.status(204).end();
+  })
+);
+router.post('/Sessions/Playing/Ping', (_req, res) => {
+  res.status(204).end();
+});
+
+async function userDataResponse(ctx: JellyfinRequestContext, itemId: string) {
+  const d = await decodeJellyfinId(itemId);
+  if (!d) return null;
+  const { itemFromDescriptor } = await import('./items.js');
+  const row = await JellyfinRepository.getPlaystate(ctx.uuid, itemId);
+  const item = await itemFromDescriptor(ctx, d, {
+    playstate: row ?? undefined,
+  });
+  return item?.UserData ?? null;
+}
+
+router.post(
+  ['/Users/:userId/PlayedItems/:itemId', '/UserPlayedItems/:itemId'],
+  jf(async (req, res, ctx) => {
+    const id = param(req, 'itemId').replace(/-/g, '').toLowerCase();
+    const d = await decodeJellyfinId(id);
+    if (!d) {
+      res.status(404).json({ Message: 'Item not found' });
+      return;
+    }
+    if (d.k === 'series' || d.k === 'season') {
+      const { episodesForSeries } = await import('./items.js');
+      const r = await episodesForSeries(
+        ctx,
+        d,
+        d.k === 'season' ? d.s : undefined
+      );
+      for (const ep of r?.episodes ?? []) {
+        const epDesc = (ep as { _aio?: { descriptor: JellyfinItemDescriptor } })
+          ._aio?.descriptor;
+        if (!epDesc) continue;
+        await JellyfinRepository.upsertPlaystate(ctx.uuid, ep.Id, epDesc, {
+          played: true,
+          positionTicks: 0,
+          incrementPlayCount: true,
+          lastPlayedAt: Date.now(),
+        });
+      }
+    } else {
+      await JellyfinRepository.upsertPlaystate(ctx.uuid, id, d, {
+        played: true,
+        positionTicks: 0,
+        incrementPlayCount: true,
+        lastPlayedAt: Date.now(),
+      });
+    }
+    res.json((await userDataResponse(ctx, id)) ?? { Played: true });
+  })
+);
+router.delete(
+  ['/Users/:userId/PlayedItems/:itemId', '/UserPlayedItems/:itemId'],
+  jf(async (req, res, ctx) => {
+    const id = param(req, 'itemId').replace(/-/g, '').toLowerCase();
+    const d = await decodeJellyfinId(id);
+    if (!d) {
+      res.status(404).json({ Message: 'Item not found' });
+      return;
+    }
+    if (d.k === 'series' || d.k === 'season') {
+      const { episodesForSeries } = await import('./items.js');
+      const r = await episodesForSeries(
+        ctx,
+        d,
+        d.k === 'season' ? d.s : undefined
+      );
+      for (const ep of r?.episodes ?? []) {
+        const epDesc = (ep as { _aio?: { descriptor: JellyfinItemDescriptor } })
+          ._aio?.descriptor;
+        if (!epDesc) continue;
+        await JellyfinRepository.upsertPlaystate(ctx.uuid, ep.Id, epDesc, {
+          played: false,
+          positionTicks: 0,
+        });
+      }
+    } else {
+      await JellyfinRepository.upsertPlaystate(ctx.uuid, id, d, {
+        played: false,
+        positionTicks: 0,
+      });
+    }
+    res.json((await userDataResponse(ctx, id)) ?? { Played: false });
+  })
+);
+
+router.post(
+  ['/UserItems/:itemId/UserData', '/Users/:userId/Items/:itemId/UserData'],
+  jf(async (req, res, ctx) => {
+    const id = param(req, 'itemId').replace(/-/g, '').toLowerCase();
+    const d = await decodeJellyfinId(id);
+    if (!d) {
+      res.status(404).json({ Message: 'Item not found' });
+      return;
+    }
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    await JellyfinRepository.upsertPlaystate(ctx.uuid, id, d, {
+      played: typeof body.Played === 'boolean' ? body.Played : undefined,
+      favorite:
+        typeof body.IsFavorite === 'boolean' ? body.IsFavorite : undefined,
+      positionTicks:
+        typeof body.PlaybackPositionTicks === 'number'
+          ? body.PlaybackPositionTicks
+          : undefined,
+    });
+    res.json((await userDataResponse(ctx, id)) ?? {});
+  })
+);
+router.get(
+  ['/UserItems/:itemId/UserData', '/Users/:userId/Items/:itemId/UserData'],
+  jf(async (req, res, ctx) => {
+    const id = param(req, 'itemId').replace(/-/g, '').toLowerCase();
+    res.json((await userDataResponse(ctx, id)) ?? {});
+  })
+);
+
+export default router;

--- a/packages/server/src/routes/jellyfin/relay-target.test.ts
+++ b/packages/server/src/routes/jellyfin/relay-target.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { isRelayLoop } from './relay-target.js';
+
+const SELF = new Set(['https://aio.example.com', 'http://localhost:3000']);
+
+describe('isRelayLoop', () => {
+  it('rejects a target pointing back at this server’s own image relay', () => {
+    expect(
+      isRelayLoop(
+        'https://aio.example.com/jellyfin/Items/abc123/Images/Primary',
+        SELF
+      )
+    ).toBe(true);
+    expect(
+      isRelayLoop(
+        'https://aio.example.com/jellyfin/uuid/pwd/Items/abc/Images/Backdrop/0',
+        SELF
+      )
+    ).toBe(true);
+    expect(
+      isRelayLoop('http://localhost:3000/jellyfin/Items/x/Images/Logo', SELF)
+    ).toBe(true);
+  });
+
+  it('rejects a target pointing back at the subtitle relay', () => {
+    expect(
+      isRelayLoop(
+        'https://aio.example.com/jellyfin/Videos/item1/ms1/Subtitles/0/0/Stream.srt',
+        SELF
+      )
+    ).toBe(true);
+  });
+
+  it('allows other routes on this same origin', () => {
+    expect(
+      isRelayLoop('https://aio.example.com/builtins/gdrive/poster.jpg', SELF)
+    ).toBe(false);
+    expect(isRelayLoop('https://aio.example.com/logo.png', SELF)).toBe(false);
+    expect(
+      isRelayLoop('https://aio.example.com/api/v1/posters/abc.jpg', SELF)
+    ).toBe(false);
+  });
+
+  it('allows relay-shaped paths on somebody else’s origin', () => {
+    expect(
+      isRelayLoop(
+        'https://images.metahub.space/poster/medium/tt0111161/img',
+        SELF
+      )
+    ).toBe(false);
+    expect(
+      isRelayLoop(
+        'https://other.example.com/jellyfin/Items/abc/Images/Primary',
+        SELF
+      )
+    ).toBe(false);
+  });
+
+  it('treats an unparseable target as not-a-loop, leaving it to the fetch', () => {
+    expect(isRelayLoop('not a url', SELF)).toBe(false);
+    expect(isRelayLoop('', SELF)).toBe(false);
+  });
+});

--- a/packages/server/src/routes/jellyfin/relay-target.ts
+++ b/packages/server/src/routes/jellyfin/relay-target.ts
@@ -1,0 +1,16 @@
+const RELAY_ROUTE =
+  /\/(Items\/[^/]+\/Images|Videos\/[^/]+\/[^/]+\/Subtitles)(\/|$)/i;
+
+export function isRelayLoop(
+  url: string,
+  selfOrigins: ReadonlySet<string>
+): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (!selfOrigins.has(parsed.origin)) return false;
+  return RELAY_ROUTE.test(parsed.pathname);
+}

--- a/packages/server/src/routes/jellyfin/system.ts
+++ b/packages/server/src/routes/jellyfin/system.ts
@@ -1,0 +1,644 @@
+import { Router, type Request, type Response } from 'express';
+import {
+  config as appConfig,
+  createLogger,
+  encryptString,
+  isConfigUuid,
+  resolveConfigAlias,
+  UserRepository,
+  uuidToJellyfinUserId,
+  JellyfinRepository,
+} from '@aiostreams/core';
+import {
+  JELLYFIN_PRODUCT_NAME,
+  JELLYFIN_SERVER_VERSION,
+  jf,
+  mintToken,
+  parseMediaBrowserHeader,
+  requestOrigin,
+  resolveUserData,
+  serverIdFor,
+  type JellyfinRequestContext,
+  param,
+} from './context.js';
+
+const logger = createLogger('jellyfin');
+const router: Router = Router({ mergeParams: true });
+
+const serverName = () => appConfig.branding.addonName || 'AIOStreams';
+
+function publicInfo(req: Request) {
+  const ctx = req.jf;
+  return {
+    LocalAddress: `${requestOrigin(req)}${req.baseUrl}`,
+    ServerName: ctx?.userData.addonName || serverName(),
+    Version: JELLYFIN_SERVER_VERSION,
+    ProductName: JELLYFIN_PRODUCT_NAME,
+    OperatingSystem: 'Linux',
+    Id: ctx?.serverId ?? 'aiostreams00000000000000000000000',
+    StartupWizardCompleted: true,
+  };
+}
+
+router.get('/System/Info/Public', (req, res) => {
+  res.json(publicInfo(req));
+});
+
+router.get(
+  '/System/Info',
+  jf(async (req, res, ctx) => {
+    res.json({
+      ...publicInfo(req),
+      SystemArchitecture: 'X64',
+      OperatingSystemDisplayName: 'Linux',
+      HasPendingRestart: false,
+      IsShuttingDown: false,
+      SupportsLibraryMonitor: false,
+      WebSocketPortNumber: appConfig.bootstrap.port,
+      CompletedInstallations: [],
+      CanSelfRestart: false,
+      CanLaunchWebBrowser: false,
+      ProgramDataPath: '/config',
+      WebPath: '/web',
+      ItemsByNamePath: '/config/metadata',
+      CachePath: '/cache',
+      LogPath: '/config/log',
+      InternalMetadataPath: '/config/metadata',
+      TranscodingTempPath: '/cache/transcodes',
+      HasUpdateAvailable: false,
+      EncoderLocation: 'NotFound',
+      PackageName: 'aiostreams',
+      LocalAddress: `${requestOrigin(req)}${req.baseUrl}`,
+      ServerName: ctx.userData.addonName || serverName(),
+    });
+  })
+);
+
+router.all('/System/Ping', (_req, res) => {
+  res.json(JELLYFIN_PRODUCT_NAME);
+});
+
+router.get('/System/Endpoint', (req, res) => {
+  res.json({ IsLocal: false, IsInNetwork: false });
+});
+
+router.get(
+  '/System/Configuration',
+  jf(async (_req, res) => {
+    res.json({
+      EnableMetrics: false,
+      ServerName: serverName(),
+      PreferredMetadataLanguage: 'en',
+      MetadataCountryCode: 'US',
+      EnableCaseSensitiveItemIds: true,
+      EnableFolderView: false,
+      EnableGroupingIntoCollections: false,
+      DisplaySpecialsWithinSeasons: true,
+      UICulture: 'en-US',
+      SaveMetadataHidden: false,
+      ContentTypes: [],
+      RemoteClientBitrateLimit: 0,
+      EnableSlowResponseWarning: false,
+      LibraryScanFanoutConcurrency: 0,
+      LibraryMetadataRefreshConcurrency: 0,
+      PluginRepositories: [],
+      CorsHosts: ['*'],
+      IsStartupWizardCompleted: true,
+    });
+  })
+);
+
+router.get('/Branding/Configuration', (_req, res) => {
+  res.json({
+    LoginDisclaimer: `Sign in with your ${serverName()} config UUID and password.`,
+    CustomCss: '',
+    SplashscreenEnabled: false,
+  });
+});
+router.get(['/Branding/Css', '/Branding/Css.css'], (_req, res) => {
+  res.type('text/css').send('');
+});
+router.get('/Branding/Splashscreen', (_req, res) => {
+  res.redirect(302, '/logo.png');
+});
+
+function userDto(
+  ctx: Pick<JellyfinRequestContext, 'uuid' | 'userData' | 'serverId'>
+) {
+  const userId = uuidToJellyfinUserId(ctx.uuid);
+  return {
+    Name: ctx.userData.addonName || serverName(),
+    ServerId: ctx.serverId,
+    Id: userId,
+    HasPassword: true,
+    HasConfiguredPassword: true,
+    HasConfiguredEasyPassword: false,
+    EnableAutoLogin: true,
+    LastLoginDate: new Date().toISOString(),
+    LastActivityDate: new Date().toISOString(),
+    Configuration: userConfiguration(),
+    Policy: userPolicy(),
+  };
+}
+
+function userConfiguration() {
+  return {
+    PlayDefaultAudioTrack: true,
+    SubtitleLanguagePreference: '',
+    DisplayMissingEpisodes: false,
+    GroupedFolders: [],
+    SubtitleMode: 'Default',
+    DisplayCollectionsView: false,
+    EnableLocalPassword: false,
+    OrderedViews: [],
+    LatestItemsExcludes: [],
+    MyMediaExcludes: [],
+    HidePlayedInLatest: true,
+    RememberAudioSelections: true,
+    RememberSubtitleSelections: true,
+    EnableNextEpisodeAutoPlay: true,
+    CastReceiverId: '',
+  };
+}
+
+function userPolicy() {
+  return {
+    IsAdministrator: false,
+    IsHidden: false,
+    EnableCollectionManagement: false,
+    EnableSubtitleManagement: false,
+    EnableLyricManagement: false,
+    IsDisabled: false,
+    BlockedTags: [],
+    AllowedTags: [],
+    EnableUserPreferenceAccess: true,
+    AccessSchedules: [],
+    BlockUnratedItems: [],
+    EnableRemoteControlOfOtherUsers: false,
+    EnableSharedDeviceControl: false,
+    EnableRemoteAccess: true,
+    EnableLiveTvManagement: false,
+    EnableLiveTvAccess: false,
+    EnableMediaPlayback: true,
+    EnableAudioPlaybackTranscoding: false,
+    EnableVideoPlaybackTranscoding: false,
+    EnablePlaybackRemuxing: false,
+    ForceRemoteSourceTranscoding: false,
+    EnableContentDeletion: false,
+    EnableContentDeletionFromFolders: [],
+    EnableContentDownloading: true,
+    EnableSyncTranscoding: false,
+    EnableMediaConversion: false,
+    EnabledDevices: [],
+    EnableAllDevices: true,
+    EnabledChannels: [],
+    EnableAllChannels: true,
+    EnabledFolders: [],
+    EnableAllFolders: true,
+    InvalidLoginAttemptCount: 0,
+    LoginAttemptsBeforeLockout: -1,
+    MaxActiveSessions: 0,
+    EnablePublicSharing: false,
+    BlockedMediaFolders: [],
+    BlockedChannels: [],
+    RemoteClientBitrateLimit: 0,
+    AuthenticationProviderId:
+      'Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider',
+    PasswordResetProviderId:
+      'Jellyfin.Server.Implementations.Users.DefaultPasswordResetProvider',
+    SyncPlayAccess: 'None',
+  };
+}
+
+function sessionInfo(ctx: JellyfinRequestContext, req: Request) {
+  const mb = parseMediaBrowserHeader(
+    req.get('authorization') ?? req.get('x-emby-authorization')
+  );
+  return {
+    PlayState: {
+      CanSeek: true,
+      IsPaused: false,
+      IsMuted: false,
+      RepeatMode: 'RepeatNone',
+      PlaybackOrder: 'Default',
+    },
+    AdditionalUsers: [],
+    Capabilities: {
+      PlayableMediaTypes: ['Video'],
+      SupportedCommands: [],
+      SupportsMediaControl: false,
+      SupportsPersistentIdentifier: false,
+    },
+    RemoteEndPoint: req.userIp ?? '',
+    PlayableMediaTypes: ['Video'],
+    Id: `${ctx.userId}-${mb.deviceid ?? 'device'}`,
+    UserId: ctx.userId,
+    UserName: ctx.userData.addonName || serverName(),
+    Client: mb.client ?? 'Unknown',
+    LastActivityDate: new Date().toISOString(),
+    LastPlaybackCheckIn: new Date(0).toISOString(),
+    DeviceName: mb.device ?? 'Unknown',
+    DeviceId: mb.deviceid ?? 'unknown',
+    ApplicationVersion: mb.version ?? '0',
+    IsActive: true,
+    SupportsMediaControl: false,
+    SupportsRemoteControl: false,
+    NowPlayingQueue: [],
+    NowPlayingQueueFullItems: [],
+    HasCustomDeviceName: false,
+    ServerId: ctx.serverId,
+    SupportedCommands: [],
+  };
+}
+
+router.get('/Users/Public', (req, res) => {
+  if (req.jf?.preAuthenticated) {
+    res.json([userDto(req.jf)]);
+    return;
+  }
+  res.json([]);
+});
+
+router.post('/Users/AuthenticateByName', async (req, res) => {
+  try {
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const username = String(body.Username ?? body.username ?? '').trim();
+    const pw = String(
+      body.Pw ?? body.pw ?? body.Password ?? body.password ?? ''
+    );
+    const mb = parseMediaBrowserHeader(
+      req.get('authorization') ?? req.get('x-emby-authorization')
+    );
+
+    let uuid: string | undefined;
+    let encryptedPassword: string | undefined;
+
+    if (req.jf?.preAuthenticated) {
+      uuid = req.jf.uuid;
+      encryptedPassword = req.jf.encryptedPassword;
+    } else {
+      if (!username) {
+        res
+          .status(401)
+          .json({ Message: 'Username (config UUID or alias) is required' });
+        return;
+      }
+      let candidate = username;
+      if (!isConfigUuid(candidate)) {
+        const alias = await resolveConfigAlias(candidate);
+        if (!alias) {
+          res.status(401).json({ Message: 'Unknown user' });
+          return;
+        }
+        candidate = alias.uuid;
+        uuid = candidate;
+        encryptedPassword = alias.encryptedPassword;
+      } else {
+        const enc = encryptString(pw);
+        if (!enc.success || !enc.data) {
+          res.status(500).json({ Message: 'Encryption failure' });
+          return;
+        }
+        uuid = candidate;
+        encryptedPassword = enc.data;
+      }
+    }
+
+    const resolved = await resolveUserData(
+      uuid!,
+      encryptedPassword!,
+      req.userIp
+    );
+    if (!resolved) {
+      res.status(401).json({ Message: 'Invalid username or password' });
+      return;
+    }
+    const token = mintToken({
+      u: resolved.uuid,
+      p: encryptedPassword!,
+      d: mb.deviceid,
+    });
+    const ctx = {
+      uuid: resolved.uuid,
+      userData: resolved.userData,
+      serverId: serverIdFor(resolved.uuid),
+      userId: uuidToJellyfinUserId(resolved.uuid),
+    } as JellyfinRequestContext;
+    logger.info(
+      { uuid: resolved.uuid, client: mb.client, device: mb.device },
+      'jellyfin client authenticated'
+    );
+    res.json({
+      User: userDto(ctx),
+      SessionInfo: sessionInfo(ctx, req),
+      AccessToken: token,
+      ServerId: ctx.serverId,
+    });
+  } catch (error) {
+    logger.error(
+      `authenticate failed: ${error instanceof Error ? error.message : error}`
+    );
+    res.status(500).json({ Message: 'Authentication failed' });
+  }
+});
+
+router.post('/Users/AuthenticateWithQuickConnect', (_req, res) => {
+  res.status(401).json({ Message: 'Quick Connect is not available' });
+});
+router.get('/QuickConnect/Enabled', (_req, res) => {
+  res.json(false);
+});
+router.all(
+  [
+    '/QuickConnect/Initiate',
+    '/QuickConnect/Connect',
+    '/QuickConnect/Authorize',
+  ],
+  (_req, res) => {
+    res.status(401).json({ Message: 'Quick Connect is not available' });
+  }
+);
+
+router.post('/Sessions/Logout', (_req, res) => {
+  res.status(204).end();
+});
+
+router.get(
+  '/Users/Me',
+  jf(async (_req, res, ctx) => {
+    res.json(userDto(ctx));
+  })
+);
+router.get(
+  '/Users',
+  jf(async (_req, res, ctx) => {
+    res.json([userDto(ctx)]);
+  })
+);
+router.get(
+  '/Users/:userId',
+  jf(async (_req, res, ctx) => {
+    res.json(userDto(ctx));
+  })
+);
+router.get(
+  '/Users/:userId/Configuration',
+  jf(async (_req, res) => {
+    res.json(userConfiguration());
+  })
+);
+router.post(
+  ['/Users/:userId/Configuration', '/Users/Configuration'],
+  jf(async (_req, res) => {
+    res.status(204).end();
+  })
+);
+router.post(
+  [
+    '/Users/:userId/Policy',
+    '/Users/:userId/Password',
+    '/Users/:userId/EasyPassword',
+  ],
+  jf(async (_req, res) => {
+    res.status(204).end();
+  })
+);
+
+router.get(
+  '/Sessions',
+  jf(async (req, res, ctx) => {
+    res.json([sessionInfo(ctx, req)]);
+  })
+);
+router.post(
+  ['/Sessions/Capabilities', '/Sessions/Capabilities/Full'],
+  jf(async (_req, res) => {
+    res.status(204).end();
+  })
+);
+router.post(
+  '/Sessions/Viewing',
+  jf(async (_req, res) => {
+    res.status(204).end();
+  })
+);
+router.all(
+  '/Sessions/:sessionId/{*rest}',
+  (req, _res, next) =>
+    /^playing$/i.test(String(req.params.sessionId)) ? next('route') : next(),
+  jf(async (_req, res) => {
+    res.status(204).end();
+  })
+);
+router.get(
+  '/Devices',
+  jf(async (req, res, ctx) => {
+    res.json({
+      Items: [
+        {
+          Name: ctx.client.device,
+          Id: ctx.client.deviceId,
+          LastUserName: ctx.userData.addonName || serverName(),
+          AppName: ctx.client.name,
+          AppVersion: ctx.client.version,
+          LastUserId: ctx.userId,
+          DateLastActivity: new Date().toISOString(),
+        },
+      ],
+      TotalRecordCount: 1,
+      StartIndex: 0,
+    });
+  })
+);
+router.get(
+  '/Devices/Info',
+  jf(async (_req, res, ctx) => {
+    res.json({
+      Name: ctx.client.device,
+      Id: ctx.client.deviceId,
+      AppName: ctx.client.name,
+      AppVersion: ctx.client.version,
+    });
+  })
+);
+router.get(
+  '/Devices/Options',
+  jf(async (_req, res) => {
+    res.json({ CustomName: null });
+  })
+);
+router.post(
+  '/Devices/Options',
+  jf(async (_req, res) => {
+    res.status(204).end();
+  })
+);
+
+const DEFAULT_DISPLAY_PREFS = (id: string, client: string) => ({
+  Id: id,
+  ViewType: null,
+  SortBy: 'SortName',
+  IndexBy: null,
+  RememberIndexing: false,
+  PrimaryImageHeight: 250,
+  PrimaryImageWidth: 250,
+  CustomPrefs: {},
+  ScrollDirection: 'Horizontal',
+  ShowBackdrop: true,
+  RememberSorting: false,
+  SortOrder: 'Ascending',
+  ShowSidebar: false,
+  Client: client,
+});
+
+router.get(
+  '/DisplayPreferences/:id',
+  jf(async (req, res, ctx) => {
+    const client =
+      (typeof req.query.client === 'string' ? req.query.client : 'emby') ||
+      'emby';
+    const stored = await JellyfinRepository.getDisplayPrefs(
+      ctx.uuid,
+      param(req, 'id'),
+      client
+    );
+    res.json({
+      ...DEFAULT_DISPLAY_PREFS(param(req, 'id'), client),
+      ...(stored ?? {}),
+    });
+  })
+);
+router.post(
+  '/DisplayPreferences/:id',
+  jf(async (req, res, ctx) => {
+    const client =
+      (typeof req.query.client === 'string' ? req.query.client : 'emby') ||
+      'emby';
+    const body = (
+      req.body && typeof req.body === 'object' ? req.body : {}
+    ) as Record<string, unknown>;
+    await JellyfinRepository.setDisplayPrefs(
+      ctx.uuid,
+      param(req, 'id'),
+      client,
+      body
+    );
+    res.status(204).end();
+  })
+);
+
+router.get('/Localization/Cultures', (_req, res) => {
+  res.json([
+    {
+      Name: 'English',
+      DisplayName: 'English',
+      TwoLetterISOLanguageName: 'en',
+      ThreeLetterISOLanguageName: 'eng',
+      ThreeLetterISOLanguageNames: ['eng'],
+    },
+  ]);
+});
+router.get('/Localization/Countries', (_req, res) => {
+  res.json([
+    {
+      Name: 'US',
+      DisplayName: 'United States',
+      TwoLetterISORegionName: 'US',
+      ThreeLetterISORegionName: 'USA',
+    },
+  ]);
+});
+router.get('/Localization/Options', (_req, res) => {
+  res.json([{ Name: 'English (United States)', Value: 'en-US' }]);
+});
+router.get('/Localization/ParentalRatings', (_req, res) => {
+  res.json([]);
+});
+
+for (const p of [
+  '/Plugins',
+  '/ScheduledTasks',
+  '/Packages',
+  '/Repositories',
+  '/Notifications/Types',
+  '/Notifications/Services',
+  '/System/ActivityLog/Entries',
+  '/Auth/Keys',
+  '/Auth/PasswordResetProviders',
+  '/Auth/Providers',
+  '/Environment/Drives',
+  '/Environment/NetworkShares',
+  '/Library/PhysicalPaths',
+  '/Sessions/SyncPlay/List',
+  '/SyncPlay/List',
+  '/LiveTv/Programs',
+  '/LiveTv/Recordings',
+  '/LiveTv/Timers',
+  '/LiveTv/SeriesTimers',
+  '/LiveTv/Channels',
+  '/LiveTv/Programs/Recommended',
+  '/Channels',
+  '/Playlists',
+  '/Collections',
+  '/Studios',
+  '/Artists',
+  '/Artists/AlbumArtists',
+  '/Years',
+  '/Persons',
+  '/Trailers',
+  '/Audio/Genres',
+  '/MusicGenres',
+  '/Items/Intros',
+  '/Users/:userId/Items/Intros',
+]) {
+  router.get(p, (_req, res) => {
+    if (
+      /Items|Channels|Playlists|Collections|Studios|Artists|Years|Persons|Trailers|Genres|Programs|Recordings|Timers|Intros|Entries/.test(
+        p
+      )
+    ) {
+      res.json({ Items: [], TotalRecordCount: 0, StartIndex: 0 });
+    } else {
+      res.json([]);
+    }
+  });
+}
+router.get('/LiveTv/Info', (_req, res) => {
+  res.json({ Services: [], IsEnabled: false, EnabledUsers: [] });
+});
+router.get('/LiveTv/GuideInfo', (_req, res) => {
+  res.json({
+    StartDate: new Date().toISOString(),
+    EndDate: new Date().toISOString(),
+  });
+});
+router.get('/Notifications/:userId/Summary', (_req, res) => {
+  res.json({ UnreadCount: 0, MaxUnreadNotificationLevel: 'Normal' });
+});
+router.get('/Notifications/:userId', (_req, res) => {
+  res.json({ Notifications: [], TotalRecordCount: 0 });
+});
+router.get('/Playback/BitrateTest', (req, res) => {
+  const size = Math.min(
+    Number(req.query.Size ?? req.query.size ?? 102400) || 102400,
+    10 * 1024 * 1024
+  );
+  res.type('application/octet-stream').send(Buffer.alloc(size));
+});
+router.get('/Startup/{*rest}', (_req, res) => {
+  res.json({});
+});
+router.post('/Startup/{*rest}', (_req, res) => {
+  res.status(204).end();
+});
+router.post(['/Items/:itemId/Refresh', '/Library/Refresh'], (_req, res) => {
+  res.status(204).end();
+});
+router.get('/ClientLog/Document', (_req, res) => {
+  res.status(204).end();
+});
+router.post('/ClientLog/Document', (_req, res) => {
+  res.json({ FileName: 'client.log' });
+});
+
+export default router;

--- a/packages/server/src/routes/jellyfin/tasks.ts
+++ b/packages/server/src/routes/jellyfin/tasks.ts
@@ -1,0 +1,23 @@
+import { JellyfinRepository, TaskManager } from '@aiostreams/core';
+
+const ITEM_MAX_AGE_MS = 180 * 24 * 3600 * 1000;
+const PRUNE_INTERVAL_MS = 24 * 3600 * 1000;
+
+export function registerJellyfinTasks(): void {
+  TaskManager.register({
+    id: 'prune-jellyfin-items',
+    label: 'Prune Jellyfin id mappings',
+    description:
+      'Deletes hashed Jellyfin item id mappings older than 180 days that no watch state references. Browsing re-creates them.',
+    category: 'users',
+    kind: 'scheduled',
+    intervalMs: PRUNE_INTERVAL_MS,
+    enabled: true,
+    destructive: true,
+    multiReplica: 'single',
+    run: async () => {
+      const n = await JellyfinRepository.pruneItems(ITEM_MAX_AGE_MS);
+      return { ok: true, message: `pruned ${n} jellyfin id mappings` };
+    },
+  });
+}

--- a/packages/server/src/routes/jellyfin/ws.ts
+++ b/packages/server/src/routes/jellyfin/ws.ts
@@ -1,0 +1,94 @@
+import type { Server as HttpServer, IncomingMessage } from 'http';
+import type { Duplex } from 'stream';
+import { WebSocketServer, type WebSocket } from 'ws';
+import { createLogger } from '@aiostreams/core';
+import { readToken, verifyCredentials } from './context.js';
+
+const logger = createLogger('jellyfin');
+
+const MAX_SOCKETS_PER_USER = 16;
+const MAX_SOCKETS_TOTAL = 50_000;
+
+const SOCKET_PATH =
+  /^\/jellyfin(?:\/([^/?]+)\/([^/?]+))?(?:\/emby)?\/socket(?:\?|$)/i;
+
+function reject(socket: Duplex, status: number, text: string) {
+  socket.write(`HTTP/1.1 ${status} ${text}\r\nConnection: close\r\n\r\n`);
+  socket.destroy();
+}
+
+async function authenticateUpgrade(url: string): Promise<string | null> {
+  const m = SOCKET_PATH.exec(url);
+  if (!m) return null;
+  const query = new URLSearchParams(url.split('?')[1] ?? '');
+  const apiKey = query.get('api_key') ?? query.get('ApiKey') ?? '';
+  if (apiKey) {
+    const payload = readToken(apiKey);
+    if (payload) return verifyCredentials(payload.u, payload.p);
+  }
+  if (m[1] && m[2]) {
+    return verifyCredentials(decodeURIComponent(m[1]), m[2]);
+  }
+  return null;
+}
+
+export function attachJellyfinWebSocket(server: HttpServer): void {
+  const wss = new WebSocketServer({ noServer: true });
+  const perUser = new Map<string, number>();
+
+  wss.on('connection', (ws: WebSocket, _req: IncomingMessage, uuid: string) => {
+    perUser.set(uuid, (perUser.get(uuid) ?? 0) + 1);
+    const send = (MessageType: string, Data: unknown = null) => {
+      if (ws.readyState === ws.OPEN)
+        ws.send(JSON.stringify({ MessageType, Data }));
+    };
+    send('ForceKeepAlive', 60);
+    const timer = setInterval(() => send('KeepAlive'), 30_000);
+    const release = () => {
+      clearInterval(timer);
+      const n = (perUser.get(uuid) ?? 1) - 1;
+      if (n <= 0) perUser.delete(uuid);
+      else perUser.set(uuid, n);
+    };
+    ws.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(String(raw)) as { MessageType?: string };
+        if (msg.MessageType === 'KeepAlive') send('KeepAlive');
+      } catch {}
+    });
+    ws.on('close', release);
+    ws.on('error', release);
+  });
+
+  server.on('upgrade', (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+    const url = req.url ?? '';
+    if (!SOCKET_PATH.test(url)) return;
+    void authenticateUpgrade(url)
+      .then((uuid) => {
+        if (socket.destroyed) return;
+        if (!uuid) {
+          reject(socket, 401, 'Unauthorized');
+          return;
+        }
+        if ((perUser.get(uuid) ?? 0) >= MAX_SOCKETS_PER_USER) {
+          reject(socket, 429, 'Too Many Requests');
+          return;
+        }
+        if (wss.clients.size >= MAX_SOCKETS_TOTAL) {
+          reject(socket, 503, 'Service Unavailable');
+          return;
+        }
+        wss.handleUpgrade(req, socket, head, (ws) => {
+          wss.emit('connection', ws, req, uuid);
+        });
+      })
+      .catch((error) => {
+        logger.debug(
+          { err: error instanceof Error ? error.message : String(error) },
+          'websocket upgrade auth failed'
+        );
+        if (!socket.destroyed) reject(socket, 500, 'Internal Server Error');
+      });
+  });
+  logger.debug('jellyfin websocket attached');
+}

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -4,6 +4,10 @@ import {
   settleMetricsHistory,
   stopMetricsHistory,
 } from './utils/system-metrics.js';
+import {
+  attachJellyfinWebSocket,
+  registerJellyfinTasks,
+} from './routes/jellyfin/index.js';
 import { startNfsShare, stopNfsShare } from './nfs.js';
 import { startFuseMount, stopFuseMount } from './fuse.js';
 
@@ -368,6 +372,7 @@ async function start() {
     registerUsenetTasks();
     registerStreamTasks();
     registerReleaseBlocklistTasks();
+    if (appConfig.api.enableJellyfinApi) registerJellyfinTasks();
     // Otherwise sessions from the last run stay active forever.
     await recoverStreamSessions().catch((error) =>
       logger.warn('Failed to recover orphaned stream sessions:', error)
@@ -387,6 +392,9 @@ async function start() {
       );
       settleMetricsHistory();
     });
+    if (appConfig.api.enableJellyfinApi) {
+      attachJellyfinWebSocket(server);
+    }
   } catch (error) {
     if (error instanceof ConfigStartupError) throw error;
     logger.error('Failed to start server:', error);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,6 +519,9 @@ importers:
       undici:
         specifier: ^7.25.0
         version: 7.28.0
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -535,6 +538,9 @@ importers:
       '@types/proxy-addr':
         specifier: ^2.0.3
         version: 2.0.3
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
 
 packages:
 
@@ -2956,7 +2962,7 @@ packages:
     engines: {node: '>=0.2.6'}
 
   '@torbox/torbox-api@https://codeload.github.com/viren070/torbox-sdk-js/tar.gz/82fb4eb14ccd3a0372fb445f796fa49527960cdd':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/viren070/torbox-sdk-js/tar.gz/82fb4eb14ccd3a0372fb445f796fa49527960cdd}
+    resolution: {gitHosted: true, integrity: sha512-+iwZYfoodKQXCsiR7X1Vu2A1EZBWTLQKJVr9rNsOQGCwYvrMCkKcveFEMGz+dTZptV3hWJQVbMdpk5a3JfrkAg==, tarball: https://codeload.github.com/viren070/torbox-sdk-js/tar.gz/82fb4eb14ccd3a0372fb445f796fa49527960cdd}
     version: 1.0.9
 
   '@tsconfig/node10@1.0.12':
@@ -3113,6 +3119,9 @@ packages:
 
   '@types/user-agents@1.0.4':
     resolution: {integrity: sha512-AjeFc4oX5WPPflgKfRWWJfkEk7Wu82fnj1rROPsiqFt6yElpdGFg8Srtm/4PU4rA9UiDUZlruGPgcwTMQlwq4w==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.61.1':
     resolution: {integrity: sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==}
@@ -4359,6 +4368,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -5703,6 +5713,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
@@ -6064,6 +6075,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -9615,6 +9627,10 @@ snapshots:
   '@types/use-sync-external-store@0.0.6': {}
 
   '@types/user-agents@1.0.4': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.3
 
   '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:


### PR DESCRIPTION
Ports the Jellyfin compatibility layer published by qooode/AIOStreams (cut from a 2.33.x dev snapshot) onto a clean upstream **v2.34.0** as an additive patch.

## What it adds
- `packages/core/src/jellyfin/*`, `packages/core/src/db/repositories/jellyfin.ts`, migrations `0027_jellyfin` / `0028_jellyfin_keys` (renumbered after upstream's 2.34.0 sequence), `packages/server/src/routes/jellyfin/*` (items, library, playback, system, tasks, ws, relay-target).
- Hooks only: config fields (`ENABLE_JELLYFIN_API` default true, `JELLYFIN_MAX_CATALOG_ITEMS`, `JELLYFIN_LOOKUP_CONCURRENCY`, `JELLYFIN_RELAY_TIMEOUT`), migration registration, `UsersRepository.verifyCredentials`, router mount at `/jellyfin`, Installation > Jellyfin tab in the configure UI, `ws` dependency.
- Curated patch documenting the port: `.planning/phases/01-port/jellyfin-layer.patch`.

## How it works
Jellyfin clients (Infuse, SenPlayer, Swiftfin, Findroid, Kodi…) point at `https://<host>/jellyfin` and log in with the **profile UUID** as username and the **profile password**. Libraries = the profile's catalogs; metadata/seasons = the profile's meta addons; media sources = the profile's streams with the profile's formatter labels; direct play via 302; per-profile resume/next-up/favourites stored in the AIOStreams DB. No Jellyfin server involved, no transcoding.

## Verification
- `pnpm build` green; tests core 50/50, server 5/5, frontend 281/281 (no regressions vs v2.34.0).
- Local run: migrations apply, `jellyfin_playstate` table present, `POST /jellyfin/Users/AuthenticateByName` → 200 + AccessToken.

## Risks & Dependencies
- Upstream tracking: rebase this branch onto each new AIOStreams tag; the diff is limited to the files above.
- If Viren070/AIOStreams adopts the layer officially, this fork is retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwESYCxAgaXY8GpLuUte3c